### PR TITLE
use name validator for escaping object names

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -1014,10 +1014,15 @@ SqlFormatter.prototype.formatDelete = function(obj)
 };
 
 SqlFormatter.prototype.escapeName = function(name) {
-    if (typeof name === 'string') {
-        return new ObjectNameValidator().escape(name, this.settings.nameFormat);
+    // escape a named object e.g. { $name: 'lastName' }
+    if (typeof name === 'object' && Object.prototype.hasOwnProperty.call(name, '$name')) {
+        return this.escapeName(name.$name); 
     }
-    return name;
+    // throw error for unexpected type
+    if (typeof name !== 'string') {
+        throw new Error('Invalid name expression. Expected string.');
+    }
+    return new ObjectNameValidator().escape(name, this.settings.nameFormat);
 };
 
 function isQueryField_(obj) {

--- a/formatter.js
+++ b/formatter.js
@@ -1022,7 +1022,7 @@ SqlFormatter.prototype.escapeName = function(name) {
     if (typeof name !== 'string') {
         throw new Error('Invalid name expression. Expected string.');
     }
-    return new ObjectNameValidator().escape(name, this.settings.nameFormat);
+    return ObjectNameValidator.validator.escape(name, this.settings.nameFormat);
 };
 
 function isQueryField_(obj) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "MOST Web Framework Codename Blueshift - Query Module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR changes SqlFormatter.escapeName(name) method to use explicitly ObjectNameValidator.escape(name) for escaping database object names.