### PR TITLE
Include asterisk while validating object names

### DIFF
--- a/object-name.validator.js
+++ b/object-name.validator.js
@@ -28,7 +28,7 @@ class ObjectNameValidator {
          * Gets or sets qualified object name pattern
          * @type {RegExp}
          */
-        this.qualifiedPattern = new RegExp(`^${this.pattern.source}((\\.)${this.pattern.source})*$`);
+        this.qualifiedPattern = new RegExp(`^\\*$|^${this.pattern.source}((\\.)${this.pattern.source})*(\\.\\*)?$`);
     }
     /**
      * @param {string} name - A string which defines a query field name or an alias

--- a/object-name.validator.js
+++ b/object-name.validator.js
@@ -40,9 +40,9 @@ class ObjectNameValidator {
         const qualifiedName = typeof qualified === 'undefined' ? true : !!qualified;
         let pattern;
         if (qualifiedName) {
-            pattern = new RegExp(this.qualifiedPattern.source);
+            pattern = new RegExp(this.qualifiedPattern.source, 'g');
         } else {
-            pattern = new RegExp('^' + this.pattern.source + '$');
+            pattern = new RegExp('^' + this.pattern.source + '$', 'g');
         }
         const valid = pattern.test(name);
         if (valid === false) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "MOST Web Framework Codename Blueshift - Query Module",
   "main": "index.js",
   "scripts": {

--- a/spec/ObjectNameValidator.spec.js
+++ b/spec/ObjectNameValidator.spec.js
@@ -56,6 +56,7 @@ describe('ObjectNameValidator', () => {
 
     it('should escape column alias', () => {
         expect(ObjectNameValidator.validator.test('Table1.field1', false, false)).toBeFalse();
+        expect(ObjectNameValidator.validator.test('Table1.*', true, false)).toBeTrue();
         expect(ObjectNameValidator.validator.test('Table1.field2', false, false)).toBeFalse();
         expect(ObjectNameValidator.validator.test('field2', false)).toBeTrue();
         expect(ObjectNameValidator.validator.test('field3', false)).toBeTrue();
@@ -65,6 +66,14 @@ describe('ObjectNameValidator', () => {
         const validator = new ObjectNameValidator();
         expect(validator.escape('schema1.Table1.field1', '`$1`')).toBe('`schema1`.`Table1`.`field1`');
         expect(validator.escape('dbo.Table1', '`$1`')).toBe('`dbo`.`Table1`');
+    });
+    it('should escape wilcard expression', () => {
+        const validator = new ObjectNameValidator();
+        expect(validator.escape('*', '`$1`')).toBe('*');
+        expect(() => { validator.escape('Table1.**', '`$1`') }).toThrowError();
+        expect(validator.escape('Table1.*', '`$1`')).toBe('`Table1`.*');
+        expect(() => { validator.escape('dob.*Table1', '`$1`') }).toThrowError();
+        expect(validator.escape('dbo.Table1.*', '`$1`')).toBe('`dbo`.`Table1`.*');
     });
 
 });


### PR DESCRIPTION
This PR closes #21 by modifying validation pattern and includes asterisk in both object or qualified object names e.g. `*`, `schema1.Table1.*` etc.