### PR TITLE
Export member resolvers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3128,6 +3128,11 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "async": "^3.2.3",
     "esprima": "^4.0.0",
     "lodash": "^4.17.15",
-    "sprintf-js": "^1.1.2"
+    "sprintf-js": "^1.1.2",
+    "tapable": "^2.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/closures/ClosureParser.d.ts
+++ b/src/closures/ClosureParser.d.ts
@@ -1,4 +1,6 @@
 // MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP All rights reserved
+import {SyncHook} from 'tapable';
+
 export type SelectClosure = (x: any) => any;
 export type FilterClosure = (x: any) => any;
 
@@ -26,7 +28,7 @@ export declare class ClosureParser {
     parseMethod(expr: any): any;
     parseIdentifier(expr: any): any;
     parseLiteral(expr: any): any;
-    resolveMember(member: any): any;
-    resolveJoinMember(member: any): any;
-    resolveMethod(method: any): any;
+    resolvingMember: (event: { target: ClosureParser, member: string }) => void;
+    resolvingJoinMember: (event: { target: ClosureParser, member: string }) => void;
+    resolvingMethod: (event: { target: ClosureParser, method: string }) => void;
 }

--- a/src/closures/ClosureParser.d.ts
+++ b/src/closures/ClosureParser.d.ts
@@ -28,7 +28,7 @@ export declare class ClosureParser {
     parseMethod(expr: any): any;
     parseIdentifier(expr: any): any;
     parseLiteral(expr: any): any;
-    resolvingMember: (event: { target: ClosureParser, member: string }) => void;
+    resolvingMember: (event: { target: ClosureParser, member: string, fullyQualifiedMember?: string }) => void;
     resolvingJoinMember: (event: { target: ClosureParser, member: string }) => void;
     resolvingMethod: (event: { target: ClosureParser, method: string }) => void;
 }

--- a/src/closures/ClosureParser.js
+++ b/src/closures/ClosureParser.js
@@ -217,7 +217,7 @@ class ClosureParser {
     }
 
     /**
-     * @param {function({target:*, member:string})} eventCallback
+     * @param {function({target:*, member:string, fullyQualifiedMember: string})} eventCallback
      */
     resolvingJoinMember(eventCallback) {
         this._hooks.resolveJoinMember.tap({
@@ -545,7 +545,11 @@ class ClosureParser {
                 }
                 // find identifier name
                 let object1 = expr;
+                let fullyQualifiedMember =  '';
                 while (object1.object != null) {
+                    if (object1.object && object1.object.property) {
+                        fullyQualifiedMember += object1.object.property.name + '.';
+                    }
                     object1 = object1.object;
                 }
                 namedParam = self.namedParams.find(function (item) {
@@ -554,6 +558,12 @@ class ClosureParser {
                 if (object1.name === namedParam.name) {
                     //get closure parameter expression e.g. x.customer.name
                     let property = expr.property.name;
+                    fullyQualifiedMember += property;
+                    this._hooks.resolveJoinMember.call({
+                        target: this,
+                        member: property,
+                        fullyQualifiedMember: fullyQualifiedMember
+                    });
                     return new MemberExpression(expr.object.property.name + '.' + property);
                 }
                 else {

--- a/src/query.d.ts
+++ b/src/query.d.ts
@@ -118,6 +118,10 @@ export declare class QueryExpression {
     toLocaleLowerCase(): this;
     toLocaleUpperCase(): this;
 
+    resolvingMember: (event: { target: QueryExpression, member: string }) => void;
+    resolvingJoinMember: (event: { target: QueryExpression, member: string }) => void;
+    resolvingMethod: (event: { target: QueryExpression, method: string }) => void;
+
 }
 
 export declare class QueryField {

--- a/src/query.d.ts
+++ b/src/query.d.ts
@@ -1,4 +1,4 @@
-// MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP All rights reserved
+
 export declare class QueryExpression {
 
     static ComparisonOperators: {

--- a/src/query.d.ts
+++ b/src/query.d.ts
@@ -119,7 +119,7 @@ export declare class QueryExpression {
     toLocaleUpperCase(): this;
 
     resolvingMember: (event: { target: QueryExpression, member: string }) => void;
-    resolvingJoinMember: (event: { target: QueryExpression, member: string }) => void;
+    resolvingJoinMember: (event: { target: QueryExpression, member: string, fullyQualifiedMember?: string }) => void;
     resolvingMethod: (event: { target: QueryExpression, method: string }) => void;
 
 }

--- a/src/query.js
+++ b/src/query.js
@@ -431,7 +431,8 @@ class QueryExpression {
         closureParser.resolvingJoinMember((event) => {
             const newEvent = {
                 target: this,
-                member: event.member
+                member: event.member,
+                fullyQualifiedMember: event.fullyQualifiedMember
             };
             this._hooks.resolveJoinMember.call(newEvent);
             event.member = newEvent.member


### PR DESCRIPTION
This PR implements ClosureParser.resolvingMember() event emitter for handling the procedure of resolving a member expression. This operation is going to be used by `@themost/data` which should resolve members based on data model schemas. 