### PR TITLE
Handle undefined args

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
       "promise"
     ],
     "extends": [
-        "eslint:recommended"
+        "eslint:recommended",
+        "eslint-node:recommended"
     ],
     "rules": {
       "no-console": "warn",

--- a/formatter.js
+++ b/formatter.js
@@ -1195,9 +1195,13 @@ SqlFormatter.prototype.formatFieldEx = function(obj, format)
             fn = this[prop];
             args = expr;
             if (Array.isArray(args)) {
-                return fn.apply(this, args);
+                return fn.apply(this, args); 
             } else {
-                return fn.call(this, args);
+                if (typeof args === 'undefined') {
+                    return fn.apply(this, []);
+                } else {
+                    return fn.call(this, args);
+                }
             }
         }
         //get aggregate expression
@@ -1216,7 +1220,15 @@ SqlFormatter.prototype.formatFieldEx = function(obj, format)
                 fn = this[prop];
                 if (typeof fn === 'function') {
                     args = expr[prop];
-                    s = Array.isArray(args) ? fn.apply(this, args) : fn.call(this, args);
+                    if (Array.isArray(args)) {
+                        s = fn.apply(this, args); 
+                    } else {
+                        if (typeof args === 'undefined') {
+                            s = fn.apply(this, []);
+                        } else {
+                            s = fn.call(this, args);
+                        }
+                    }
                 }
                 else
                     throw new Error('The specified function is not yet implemented.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.5.15",
+  "version": "2.5.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.15",
+  "version": "2.5.16",
   "description": "MOST Web Framework Codename Blueshift - Query Module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This MR handles undefined args when `SqlFormatter.formatFieldEx()` is trying to format a method call expression with no arguments.