### PR TITLE
Simplify comparison expression

### DIFF
--- a/expressions.js
+++ b/expressions.js
@@ -30,13 +30,13 @@ ArithmeticExpression.prototype.exprOf = function()
     //build right operand e.g. { $add:[ 5 ] }
     var result = {};
     Object.defineProperty(result, this.operator, {
-        value: [this.left.exprOf(), this.right.exprOf()],
+        value: [
+            (this.left != null) ? (typeof this.left.exprOf === 'function' ? this.left.exprOf() : this.left) : null,
+            (this.right != null) ? (typeof this.right.exprOf === 'function' ? this.right.exprOf() : this.right) : null,
+        ],
         enumerable: true,
         configurable: true
     });
-    if (this.right == null) {
-        result[this.operator] = [null];
-    }
     //return query expression
     return result;
 };
@@ -125,66 +125,16 @@ ComparisonExpression.prototype.exprOf = function()
     if (typeof this.operator === 'undefined' || this.operator===null)
         throw new Error('Expected comparison operator.');
 
-    var p, expr, name;
-    if (this.left instanceof MethodCallExpression)
-    {
-        p = {};
-        if (typeof this.right === 'undefined' || this.right===null)
-            p[this.operator]=null;
-        else if (typeof this.right.exprOf === 'function')
-            p[this.operator] = this.right.exprOf();
-        else
-            p[this.operator]=this.right;
-
-        if (this.operator==='$eq')
-            this.left.args.push(p.$eq);
-        else
-            this.left.args.push(p);
-        //return query expression
-        return this.left.exprOf();
-    }
-    else if (this.left instanceof ArithmeticExpression)
-    {
-        p = {};
-        //build comparison expression e.g. { $gt:10 }
-        if (typeof this.right === 'undefined' || this.right===null)
-            p[this.operator]=null;
-        else if (typeof this.right.exprOf === 'function')
-            p[this.operator] = this.right.exprOf();
-        else
-            p[this.operator]=this.right;
-
-        //get left expression
-        expr = this.left.exprOf();
-        //find argument list
-        name = Object.keys(expr)[0];
-        if (this.operator==='$eq')
-            expr[name][this.left.operator].push(p.$eq);
-        else
-            expr[name][this.left.operator].push(p);
-        //return query expression
-        return expr;
-    }
-    else if (this.left instanceof MemberExpression)
-    {
-        p = {};
-        //build comparison expression e.g. { $gt:10 }
-        if (typeof this.right === 'undefined' || this.right===null)
-            p[this.operator]=null;
-        else if (typeof this.right.exprOf === 'function') {
-            p[this.operator] = this.right.exprOf();
-        }
-        else
-            p[this.operator]=this.right;
-        name = this.left.name;
-        expr = {};
-        if (this.operator==='$eq' && !(this.right instanceof MemberExpression))
-            expr[name]=p.$eq;
-        else
-            expr[name] = p;
-        //return query expression
-        return expr;
-    }
+    var result = {};
+    Object.defineProperty(result, this.operator, {
+        configurable: true,
+        enumerable: true,
+        value: [
+            (this.left != null) ? (typeof this.left.exprOf === 'function' ? this.left.exprOf() : this.left) : null,
+            (this.right != null) ? (typeof this.right.exprOf === 'function' ? this.right.exprOf() : this.right) : null
+        ]
+    });
+    return result;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.5.19",
+  "version": "2.5.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.5.19",
+      "version": "2.5.20",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.19",
+  "version": "2.5.20",
   "description": "MOST Web Framework Codename Blueshift - Query Module",
   "main": "index.js",
   "scripts": {

--- a/spec/OpenDataParser.spec.js
+++ b/spec/OpenDataParser.spec.js
@@ -9,13 +9,26 @@ describe('OpenDataParser', () => {
         const parser = new OpenDataParser();
         let expr = await parser.parseAsync('id eq 100');
         expect(expr). toEqual({
-            id: 100
+            $eq: [
+                { $name: 'id' },
+                100
+            ]
         });
         expr = await parser.parseAsync('active eq true and category eq \'Laptops\'');
-        expect(expr). toEqual({
+        expect(expr).toEqual({
             $and: [
-                { active: true },
-                { category: 'Laptops' }
+                {
+                    $eq: [
+                        { $name: 'active' },
+                        true
+                    ]
+                },
+                {
+                    $eq: [
+                        { $name: 'category' },
+                        'Laptops'
+                    ]
+                }
             ]
         });
     });


### PR DESCRIPTION
This PR simplifies `ComparisonExpression.exprOf()` to folllow simple expression format e.g.
```
$and: [
                {
                    $eq: [
                        { $name: 'active' },
                        true
                    ]
                },
                {
                    $eq: [
                        { $name: 'category' },
                        'Laptops'
                    ]
                }
            ]
```
 