### PR TITLE
Parse logical expressions without parenthesis

### DIFF
--- a/formatter.d.ts
+++ b/formatter.d.ts
@@ -17,6 +17,9 @@ export declare class SqlFormatter {
     escapeConstant(value: any,unquoted?: boolean): string;
     formatWhere(where: any): string;
 
+    $or(...arg:any): string;
+    $and(...arg:any): string;
+    $not(arg:any): string;
     $startswith(p0:any, p1:any): string;
     $endswith(p0:any, p1:any): string;
     $regex(p0:any, p1:any): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.5.20",
+  "version": "2.5.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.5.20",
+      "version": "2.5.21",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.20",
+  "version": "2.5.21",
   "description": "MOST Web Framework Codename Blueshift - Query Module",
   "main": "index.js",
   "scripts": {

--- a/spec/LogicalExpression.spec.js
+++ b/spec/LogicalExpression.spec.js
@@ -1,0 +1,84 @@
+// eslint-disable-next-line no-unused-vars
+import {QueryExpression, OpenDataParser} from '../index';
+import {MemoryAdapter} from './test/TestMemoryAdapter';
+// eslint-disable-next-line no-unused-vars
+
+describe('LogicalExpression', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll(async () => {
+        if (db) {
+            await db.closeAsync();
+        }
+    })
+    it('should use or', async () => {
+        let query = new QueryExpression().select('id', 'name', 'category').from('ProductData')
+            .where('category').equal('Laptops')
+                .or('category').equal('Monitors');
+        let results = await db.executeAsync(query);
+
+        const parser = new OpenDataParser();
+        const where = await parser.parseAsync('indexof(category, \'Lap\') ge 0 or indexof(category, \'Mon\') ge 0');
+        query = new QueryExpression().select('id', 'name', 'category').from('ProductData');
+        query.$where = where;
+        results = await db.executeAsync(query);
+        expect(results.length).toBeTruthy();
+    });
+
+    it('should use and', async () => {
+        const parser = new OpenDataParser();
+        const where = await parser.parseAsync(
+            'category eq \'Laptops\' and round(price,2) ge 550.40 and round(price,2) le 1050.40'
+            );
+        let query = new QueryExpression().select('id', 'name','price', 'category').from('ProductData');
+        query.$where = where;
+        let results = await db.executeAsync(query);
+        expect(results.length).toBeTruthy();
+    });
+
+    it('should use complex and exprssion', async () => {
+        const parser = new OpenDataParser();
+        let where = await parser.parseAsync(
+            '(category eq \'Laptops\' or category eq \'Desktops\') and round(price,2) ge 500 and round(price,2) le 1000'
+            );
+        let query = new QueryExpression().select('id', 'name','price', 'category').from('ProductData');
+        query.$where = where;
+        let results = await db.executeAsync(query);
+        expect(results.length).toBeTruthy();
+        for (const result of results) {
+            expect([
+                'Laptops',
+                'Desktops'
+            ]).toContain(result.category);
+            expect(result.price).toBeGreaterThanOrEqual(500);
+            expect(result.price).toBeLessThanOrEqual(1000);
+        }
+
+        where = await parser.parseAsync(
+            '(category eq \'Laptops\' or category eq \'Desktops\') and (round(price,2) ge 500) and (round(price,2) le 1000)'
+            );
+        query = new QueryExpression().select('id', 'name','price', 'category').from('ProductData');
+        query.$where = where;
+        results = await db.executeAsync(query);
+        expect(results.length).toBeTruthy();
+        for (const result of results) {
+            expect([
+                'Laptops',
+                'Desktops'
+            ]).toContain(result.category);
+            expect(result.price).toBeGreaterThanOrEqual(500);
+            expect(result.price).toBeLessThanOrEqual(1000);
+        }
+    });
+
+
+});


### PR DESCRIPTION
This PR fixes an error occurred while `OpenDataParser` is trying to parse logical expressions without parentheses e.g.
`(category eq 'Laptops' or category eq 'Desktops') and round(price,2) ge 500 and round(price,2) le 1000` instead of `(category eq 'Laptops' or category eq 'Desktops') and (round(price,2) ge 500) and (round(price,2) le 1000)`
