### PR TITLE
use where formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1272,7 +1272,7 @@ class SqlFormatter {
         }
         let sql = '(';
         sql += args.map((value) => {
-            return this.escape(value);
+            return this.formatWhere(value);
         }).join(' OR ');
         sql += ')';
         return sql;
@@ -1286,7 +1286,7 @@ class SqlFormatter {
         }
         let sql = '(';
         sql += args.map((value) => {
-            return this.escape(value);
+            return this.formatWhere(value);
         }).join(' AND ');
         sql += ')';
         return sql;
@@ -1294,7 +1294,7 @@ class SqlFormatter {
 
     $not(arg) {
         let sql = '(NOT ';
-        sql += this.escape(arg);
+        sql += this.formatWhere(arg);
         sql += ')';
         return sql;
     }


### PR DESCRIPTION
This PR changes logical expression formatters to use `SqlFormatter.formatWhere()` while formatting expression arguments.