### PR TITLE
use query entity object

### DIFF
--- a/src/query.d.ts
+++ b/src/query.d.ts
@@ -155,7 +155,7 @@ export declare class QueryField {
     static second(name): QueryField;
 
     select(name: string): QueryField;
-    from(entity: string): QueryField;
+    from(entity: string | QueryEntity): QueryField;
     count(name: string): QueryField;
     sum(name: string): QueryField;
     min(name: string): QueryField;


### PR DESCRIPTION
This PR closes #52 and allows the usage of an instance of `QueryEntity` class as parameter of `QueryField.from()` method.