### PR TITLE
Use method expression while ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/ClosureParser.spec.js
+++ b/spec/ClosureParser.spec.js
@@ -723,7 +723,7 @@ describe('ClosureParser', () => {
         
     });
 
-    fit('should use order by with expression', async () => {
+    it('should use order by with expression', async () => {
         const Products = new QueryEntity('ProductData');
         let a = new QueryExpression().select( x => {
             x.name,

--- a/spec/ClosureParser.spec.js
+++ b/spec/ClosureParser.spec.js
@@ -723,6 +723,27 @@ describe('ClosureParser', () => {
         
     });
 
+    fit('should use order by with expression', async () => {
+        const Products = new QueryEntity('ProductData');
+        let a = new QueryExpression().select( x => {
+            x.name,
+            x.price
+        }).from(Products).where( x => {
+            return x.category === 'Laptops';
+        }).orderBy((x) => {
+            return round(x.price, 1);
+        }).thenByDescending((x) => {
+            return x.releaseDate.getFullYear();
+        });
+        let results = await db.executeAsync(a);
+        expect(results.length).toBeTruthy();
+        results.forEach( (x, index) => {
+            if (index > 0) {
+                expect(x.price).toBeGreaterThanOrEqual(results[index-1].price);
+            }
+        });
+    });
+
     it('should use order by descending', async () => {
         const Products = new QueryEntity('ProductData');
         let a = new QueryExpression().select( x => {

--- a/src/closures/ClosureParser.js
+++ b/src/closures/ClosureParser.js
@@ -405,6 +405,8 @@ class ClosureParser {
             let objectExpression = bodyExpression.argument;
             if (objectExpression && objectExpression.type === ExpressionTypes.ObjectExpression) {
                 return self.parseObject(objectExpression);
+            } else if (objectExpression && objectExpression.type === ExpressionTypes.CallExpression) {
+                return self.parseMethod(objectExpression);
             }
         }
         throw new Error('The given expression is not yet implemented (' + expr.type + ').');


### PR DESCRIPTION
This PR enables parsing of a method call expression while using an order by closure:
```
let a = new QueryExpression().select( x => {
            x.name,
            x.price
        }).from(Products).where( x => {
            return x.category === 'Laptops';
        }).orderBy((x) => {
            return round(x.price, 1);
        }).thenByDescending((x) => {
            return x.releaseDate.getFullYear();
        });
```