### PR TITLE
add case function for open data formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -376,11 +376,23 @@ class SwitchExpression extends MethodCallExpression {
     exprOf() {
         const res = {};
         let name = '$'.concat(this.name);
+        /**
+         * @type {{branches:Array<*>,default:*}}
+         */
+        const arg0 = this.args[0];
         Object.defineProperty(res, name, {
             configurable: true,
             enumerable: true,
             writable: true,
-            value: this.args[0]
+            value: {
+                branches: arg0.branches.map((branch) => {
+                    return {
+                        case: branch.case != null && typeof branch.case.exprOf === 'function' ?  branch.case.exprOf() : branch.case,
+                        then: branch.then != null && typeof branch.then.exprOf === 'function' ?  branch.then.exprOf() : branch.then,
+                    };
+                }),
+                default: arg0.default && typeof arg0.default.exprOf === 'function' ? arg0.default.exprOf() : arg0.default
+            }
         });
         return res;
     }


### PR DESCRIPTION
This PR implements `case` dialect function for open data formatter to support OData v4 `case` method 

https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31361023

e.g.
```
let query = new OpenDataQuery().from(Products)
                .select<any>(x => {
                   return {
                    id: x.id,
                    name: x.name,
                    price: x.price,
                    priceCategory: x.price > 800 ? 'Expensive' :  (x.price <= 500 ? 'Cheap' : 'Normal')
                   }
                }).where((x:any) => {
                    return x.category === category;
                }, {
                    category
                }).orderBy<{price: number}>(x => x.price)
                .take(20);
```
which produces the following OData query
```
{
    "$select": "id,name,price,case(price gt 800:'Expensive',true:case(price le 500:'Cheap',true:'Normal')) as priceCategory",
    "$filter": "category eq 'Laptops'",
    "$orderby": "price",
    "$top": 20
}
```

