### PR TITLE
support $it while escaping value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.9.2",
+      "version": "2.9.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/OpenDataQuery.spec.js
+++ b/spec/OpenDataQuery.spec.js
@@ -287,4 +287,24 @@ describe('OpenDataQueryFormatter', () => {
         expect(result.$orderby).toEqual('birthDate,familyName desc');
     });
 
+    it('should use $it', async () => {
+        const Orders = new QueryEntity('Orders');
+        let query = new OpenDataQuery()
+            .select(({ id, customer : { familyName, givenName } }) => {
+                id,
+                givenName,
+                familyName
+            })
+            .from(Orders)
+            .where((x) => {
+                return x.customer.address.streetAddress !== x.billingAddress.streetAddress;
+            })
+            .orderBy((x) => x.customer.familyName)
+            .thenBy((x) => x.customer.givenName)
+            .take(10);
+        let result = new OpenDataQueryFormatter().formatSelect(query);
+        expect(result.$filter).toEqual('customer/address/streetAddress ne $it/billingAddress/streetAddress');
+        expect(result.$orderby).toEqual('customer/familyName,customer/givenName');
+    });
+
 });

--- a/spec/helpers/reporter.js
+++ b/spec/helpers/reporter.js
@@ -1,11 +1,11 @@
-// eslint-disable-next-line node/no-unpublished-require
-var SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
-jasmine.getEnv().clearReporters();               // remove default reporter logs
+// eslint-disable-next-line no-undef
 jasmine.getEnv().addReporter(new SpecReporter({  // add jasmine-spec-reporter
     spec: {
         displayPending: true,
         displayStacktrace: 'raw'
     }
 }));
+// eslint-disable-next-line no-undef
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;

--- a/src/open-data-query.formatter.js
+++ b/src/open-data-query.formatter.js
@@ -226,7 +226,7 @@ class OpenDataQueryFormatter extends SqlFormatter {
     }
 
     $contains(p0, p1) {
-        return sprintf('contains(%s, %s)', this.escape(p0), this.escape(p1));
+        return sprintf('contains(%s, %s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $count(p0) {

--- a/src/open-data-query.formatter.js
+++ b/src/open-data-query.formatter.js
@@ -15,12 +15,18 @@ class OpenDataQueryFormatter extends SqlFormatter {
         this.settings.forceAlias = false;
     }
 
+    escapeRight(value) {
+        if (Object.prototype.hasOwnProperty.call(value, '$name'))
+            return `$it/${this.escapeName(value.$name)}`;
+        return super.escape(value)
+    }
+
     $startswith(p0, p1) {
         return this.$startsWith(p0, p1);
     }
 
     $startsWith(p0, p1) {
-        return sprintf('startswith(%s,%s)', this.escape(p0), this.escape(p1));
+        return sprintf('startswith(%s,%s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $endswith(p0, p1) {
@@ -28,7 +34,7 @@ class OpenDataQueryFormatter extends SqlFormatter {
     }
 
     $endsWith(p0, p1) {
-        return sprintf('endswith(%s,%s)', this.escape(p0), this.escape(p1));
+        return sprintf('endswith(%s,%s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $length(p0) {
@@ -74,6 +80,7 @@ class OpenDataQueryFormatter extends SqlFormatter {
      * @param {...*} _arg 
      * @returns 
      */
+    // eslint-disable-next-line no-unused-vars
     $concat(_arg) {
         let args = Array.from(arguments);
         let self = this;
@@ -155,31 +162,31 @@ class OpenDataQueryFormatter extends SqlFormatter {
     $round(p0, p1) {
         if (p1 == null)
             p1 = 0;
-        return sprintf('round(%s,%s)', this.escape(p0), this.escape(p1));
+        return sprintf('round(%s,%s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $eq(p0, p1) {
-        return sprintf('%s eq %s', this.escape(p0), this.escape(p1));
+        return sprintf('%s eq %s', this.escape(p0), this.escapeRight(p1));
     }
 
     $ne(p0, p1) {
-        return sprintf('%s ne %s', this.escape(p0), this.escape(p1));
+        return sprintf('%s ne %s', this.escape(p0), this.escapeRight(p1));
     }
 
     $gt(p0, p1) {
-        return sprintf('%s gt %s', this.escape(p0), this.escape(p1));
+        return sprintf('%s gt %s', this.escape(p0), this.escapeRight(p1));
     }
 
     $gte(p0, p1) {
-        return sprintf('%s ge %s', this.escape(p0), this.escape(p1));
+        return sprintf('%s ge %s', this.escape(p0), this.escapeRight(p1));
     }
 
     $lt(p0, p1) {
-        return sprintf('%s lt %s', this.escape(p0), this.escape(p1));
+        return sprintf('%s lt %s', this.escape(p0), this.escapeRight(p1));
     }
 
     $lte(p0, p1) {
-        return sprintf('%s le %s', this.escape(p0), this.escape(p1));
+        return sprintf('%s le %s', this.escape(p0), this.escapeRight(p1));
     }
 
     $and(p0, p1) {
@@ -191,15 +198,15 @@ class OpenDataQueryFormatter extends SqlFormatter {
     }
 
     $add(p0, p1) {
-        return sprintf('(%s add %s)', this.escape(p0), this.escape(p1));
+        return sprintf('(%s add %s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $sub(p0, p1) {
-        return sprintf('(%s sub %s)', this.escape(p0), this.escape(p1));
+        return sprintf('(%s sub %s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $mul(p0, p1) {
-        return sprintf('(%s mul %s)', this.escape(p0), this.escape(p1));
+        return sprintf('(%s mul %s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $multiply(p0, p1) {
@@ -207,7 +214,7 @@ class OpenDataQueryFormatter extends SqlFormatter {
     }
 
     $div(p0, p1) {
-        return sprintf('(%s div %s)', this.escape(p0), this.escape(p1));
+        return sprintf('(%s div %s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $divide(p0, p1) {
@@ -215,7 +222,7 @@ class OpenDataQueryFormatter extends SqlFormatter {
     }
 
     $mod(p0, p1) {
-        return sprintf('(%s mod %s)', this.escape(p0), this.escape(p1));
+        return sprintf('(%s mod %s)', this.escape(p0), this.escapeRight(p1));
     }
 
     $contains(p0, p1) {


### PR DESCRIPTION
This PR enables the support of `$it` statement 

http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_it

while using `OpenDataQuery.where()` with javascript closures e.g.

```
new OpenDataQuery()
            .select(({ id, customer : { familyName, givenName } }) => {
                id,
                givenName,
                familyName
            })
            .from(Orders)
            .where((x) => {
                return x.customer.address.streetAddress !== x.billingAddress.streetAddress;
            });
```
which produces the following `$filter` statement:

`$filter=customer/address/streetAddress ne $it/billingAddress/streetAddress`