### PR TITLE
Add extra methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.9.3",
+      "version": "2.9.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/OpenDataQuery.spec.js
+++ b/spec/OpenDataQuery.spec.js
@@ -1,9 +1,5 @@
 import { OpenDataQuery, round, QueryEntity } from '../src/index';
-import { OpenDataQueryFormatter } from '../src/index';
-
-function me() {
-    return null;
-}
+import { OpenDataQueryFormatter, me } from '../src/index';
 
 describe('OpenDataQueryFormatter', () => {
 
@@ -319,7 +315,7 @@ describe('OpenDataQueryFormatter', () => {
             .where((x) => {
                 return x.createdBy === me();
             })
-            .orderByDescending((x) => x.dateCreate)
+            .orderByDescending((x) => x.dateCreated)
             .take(10);
         let result = new OpenDataQueryFormatter().formatSelect(query);
         expect(result.$filter).toEqual('createdBy eq me()');

--- a/spec/OpenDataQuery.spec.js
+++ b/spec/OpenDataQuery.spec.js
@@ -1,5 +1,10 @@
 import { OpenDataQuery, round, QueryEntity } from '../src/index';
 import { OpenDataQueryFormatter } from '../src/index';
+
+function me() {
+    return null;
+}
+
 describe('OpenDataQueryFormatter', () => {
 
     it('should format $select', () => {
@@ -305,6 +310,19 @@ describe('OpenDataQueryFormatter', () => {
         let result = new OpenDataQueryFormatter().formatSelect(query);
         expect(result.$filter).toEqual('customer/address/streetAddress ne $it/billingAddress/streetAddress');
         expect(result.$orderby).toEqual('customer/familyName,customer/givenName');
+    });
+
+    it('should use me() function', async () => {
+        const Orders = new QueryEntity('Orders');
+        let query = new OpenDataQuery()
+            .from(Orders)
+            .where((x) => {
+                return x.createdBy === me();
+            })
+            .orderByDescending((x) => x.dateCreate)
+            .take(10);
+        let result = new OpenDataQueryFormatter().formatSelect(query);
+        expect(result.$filter).toEqual('createdBy eq me()');
     });
 
 });

--- a/src/closures/FallbackMethodParser.js
+++ b/src/closures/FallbackMethodParser.js
@@ -62,6 +62,18 @@ class FallbackMethodParser {
     static max(args) {
         return new SimpleMethodCallExpression('max', args);
     }
+    static me() {
+        return new SimpleMethodCallExpression('me', []);
+    }
+    static today() {
+        return new SimpleMethodCallExpression('today', []);
+    }
+    static whoami() {
+        return new SimpleMethodCallExpression('today', []);
+    }
+    static now() {
+        return new SimpleMethodCallExpression('now', []);
+    }
 }
 
 export {

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -148,8 +148,9 @@ class MethodCallExpression {
         let name = '$'.concat(this.name);
         //set arguments array
         method[name] = [];
-        if (this.args.length === 0)
-            throw new Error('Unsupported method expression. Method arguments cannot be empty.');
+        if (this.args.length === 0) {
+            return method;
+        }
         //get first argument
         if (this.args[0] instanceof MemberExpression) {
             for (let i = 0; i < this.args.length; i++) {
@@ -262,8 +263,10 @@ class SimpleMethodCallExpression extends MethodCallExpression {
         let method = {};
         let name = '$'.concat(this.name);
         //set arguments array
-        if (this.args.length === 0)
-            throw new Error('Unsupported method expression. Method arguments cannot be empty.');
+        if (this.args.length === 0) {
+            method[name] = [];
+            return method;
+        }
         if (this.args.length === 1) {
             method[name] = {};
             let arg;

--- a/src/open-data-query.formatter.d.ts
+++ b/src/open-data-query.formatter.d.ts
@@ -1,5 +1,11 @@
 import { SqlFormatter } from './formatter';
 
+export declare function me(): string | number;
+export declare function whoami(): string;
+export declare function today(): Date;
+export declare function now(): Date;
+
+
 export declare class OpenDataQueryFormatter extends SqlFormatter {
     //
 }

--- a/src/open-data-query.formatter.js
+++ b/src/open-data-query.formatter.js
@@ -499,7 +499,77 @@ class OpenDataQueryFormatter extends SqlFormatter {
         }
     }
 
+    /**
+     * now() function returns the current point in time
+     * @returns {string}
+     */
+    $now() {
+        return 'now()';
+    }
+
+    /**
+     * today() function returns the current date
+     * @returns {string}
+     */
+    $today() {
+        return 'today()';
+    }
+
+    /**
+     * me() function returns the identifier of the current user
+     * @returns {string}
+     */
+    $me() {
+        return 'me()';
+    }
+
+    /**
+     * whoami() function returns the name of the current user
+     * @returns {string}
+     */
+    $whoami() {
+        return 'whoami()';
+    }
+
 }
+/**
+ * A helper function for supporting me() method while using closures for OData queries
+ * @returns {string | number}
+ */
+function me() {
+    return null;
+}
+
+/**
+ * A helper function for supporting today() method while using closures for OData queries
+ * @returns  {Date}
+ */
+function today() {
+    const value = new Date();
+    value.setHours(0,0,0,0);
+    return value;
+}
+
+/**
+ * A helper function for supporting now() method while using closures for OData queries
+ * @returns {Date}
+ */
+function now() {
+    return new Date();
+}
+
+/**
+ * A helper function for supporting whoami() method while using closures for OData queries
+ * @returns {string}
+ */
+function whoami() {
+    return null;
+}
+
 export {
+    me,
+    now,
+    today,
+    whoami,
     OpenDataQueryFormatter
 }


### PR DESCRIPTION
This PR adds extra OData methods like `me()`, `now()`, `today()` and `whoami()`  that are available while using javascript closures e.g.
```
import { OpenDataQuery, me } from '@themost/query';
new OpenDataQuery()
            .from(Orders)
            .where((x) => {
                return x.createdBy === me();
            })
            .orderByDescending((x) => x.dateCreated)
            .take(10);
```
which produces the following `$filter` statement:
`createdBy eq me()`