### PR TITLE
fix parse identifier method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/ClosureParser.spec.js
+++ b/spec/ClosureParser.spec.js
@@ -60,13 +60,16 @@ describe('ClosureParser', () => {
 
     it('should use object destructuring', async () => {
         const People = new QueryEntity('PersonData');
+        const identifier = 355;
         let a = new QueryExpression().select(({id, familyName, givenName}) => {
             id,
             familyName,
             givenName
         })
         .from(People).where( x => {
-            return x.id === 355;
+            return x.id === identifier;
+        }, {
+            identifier
         });
         expect(a.$where).toEqual({
                 $eq: [

--- a/src/closures/ClosureParser.js
+++ b/src/closures/ClosureParser.js
@@ -752,12 +752,12 @@ class ClosureParser {
         }
     }
     parseIdentifier(expr) {
+        if (this.params && Object.prototype.hasOwnProperty.call(this.params, expr.name)) {
+            return new LiteralExpression(this.params[expr.name]);
+        }
         const namedParam0 = this.namedParams && this.namedParams[0];
         if (namedParam0.type === 'ObjectPattern') {
             return this.parseMember(expr);
-        }
-        if (this.params && Object.prototype.hasOwnProperty.call(this.params, expr.name)) {
-            return new LiteralExpression(this.params[expr.name]);
         }
         throw new Error('Identifier cannot be found or is inaccessible. Consider passing parameters if they are used inside method.');
     }


### PR DESCRIPTION
This PR fixes ClosureParser.parseIdentifier() method in case of having closure params.