### PR TITLE
check typeof buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.9.5",
+      "version": "2.9.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,8 +114,10 @@ function escape(val, stringifyObjects, timeZone) {
         val = dateToString(val, timeZone || 'local');
     }
 
-    if (Buffer.isBuffer(val)) {
-        return bufferToString(val);
+    if (typeof Buffer !== 'undefined') {
+        if (Buffer.isBuffer(val)) {
+            return bufferToString(val);
+        }
     }
 
     if (Array.isArray(val)) {


### PR DESCRIPTION
This PR checks the typeof Buffer constructor which is being used by `SqlUtils.escape()` method. `Buffer` may be undefined in environments other than node.js.