### PR TITLE
fix tryUnpackedProperty syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.10",
+  "version": "2.9.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.10",
+  "version": "2.9.11",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/closures/ClosureParser.js
+++ b/src/closures/ClosureParser.js
@@ -487,7 +487,7 @@ class ClosureParser {
         ]);
     }
 
-    tryUnpackedProperty = (properties, name, qualifiedMember) => {
+    tryUnpackedProperty(properties, name, qualifiedMember) {
         let index = 0;
         while(index < properties.length) {
             const prop = properties[index];


### PR DESCRIPTION
This PR fixes `ClosureParser.tryUnpackedProperty()` syntax