### PR TITLE
Use event object and member after resolving joined member

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/closures/ClosureParser.js
+++ b/src/closures/ClosureParser.js
@@ -626,10 +626,7 @@ class ClosureParser {
                         fullyQualifiedMember: fullyQualifiedMember
                     };
                     this.resolvingJoinMember.emit(event);
-                    if (event.object !== object) {
-                        return new MemberExpression(event.object + '.' + property);
-                    }
-                    return new MemberExpression(object + '.' + property);
+                    return new MemberExpression(event.object + '.' + event.member);
                 }
                 else {
                     //evaluate object member value e.g. item.title or item.status.id


### PR DESCRIPTION
This PR assigns `event.object` and `event/member` found after resolving a joined member.