### PR TITLE
set function expression while prepare comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/query.js
+++ b/src/query.js
@@ -2043,6 +2043,40 @@ class QueryFieldComparer {
         }
         //get aggregate function
         let aggr = Object.key(this), name;
+        // compare expression with any value
+        /** 
+         * e.g. {
+         *      $ifNull: [
+         *          '$isActive',
+         *          false
+         *      ]
+         * }
+         * with {
+         *      $ne: true
+         * }
+         * which should produce an expression like IFNULL(`isActive`, false) <> false
+         */
+        if (aggr.startsWith('$') && Array.isArray(this[aggr])) {
+            // get operator
+            let op = Object.key(comparison);
+            // and create a new expression e.g. 
+            /**
+             * {
+             *      "$ne": [
+             *          $ifNull: [
+             *              '$isActive',
+             *              false
+             *          ],
+             *          true
+             *      ]
+             * }
+             */
+            expr[op] = [
+              this,
+              comparison[op]
+            ];
+            return expr;
+          }
         if (isArray(this[aggr])) {
             //get first element (the field name)
             name = QueryField.prototype.nameOf.call(this[aggr][0]);


### PR DESCRIPTION
This PR enables the usage of expressions as the first argument of a comparison e.g.

```

{
    "$ne": [
        $ifNull: [
            '$isActive',
            false
        ],
        true
    ]
}
```


