### PR TITLE
implement $getField expression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.10.3",
+      "version": "2.10.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/EscapeNameReference.spec.js
+++ b/spec/EscapeNameReference.spec.js
@@ -1,0 +1,71 @@
+import { QueryEntity, QueryExpression } from '../src/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+
+describe('EscapeNameReference', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll((done) => {
+        if (db) {
+            db.close();
+            return done();
+        }
+    });
+    it('should escape field reference', async () => {
+        const Orders = new QueryEntity('OrderData').as('orders');
+        let query = new QueryExpression()
+            .select({
+                'customer1': '$orders.customer'
+            })
+            .from(Orders).take(5);
+        let results = await db.executeAsync(query);
+        expect(results.length).toBeTruthy();
+        for(const result of results) {
+            expect(result.customer1).toBeTruthy()
+        }
+    });
+
+    it('should escape field reference in function', async () => {
+        const Products = new QueryEntity('ProductData').as('products');
+        let query = new QueryExpression()
+            .select({
+                'maxPrice': {
+                    '$max': [
+                        {
+                            '$round': [
+                                {
+                                    '$getField': 'products.price'
+                                },
+                                2
+                            ]
+                        }
+                    ]
+                }
+            }).from(Products).where('category').equal('Laptops');
+        let results = await db.executeAsync(query);
+        expect(results.length).toEqual(1);
+        const result0 = results[0];
+        expect(result0.maxPrice).toBeInstanceOf(Number);
+        expect(result0.maxPrice).toBeTruthy();
+    });
+
+    it('should not escape field reference', async () => {
+        const Products = new QueryEntity('ProductData').as('products');
+        let query = new QueryExpression()
+            .select(
+                'name',
+                'price'
+            ).from(Products).where('category').equal('$products.price');
+        let results = await db.executeAsync(query);
+        expect(results.length).toBeFalsy();
+    });
+
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ export * from './odata';
 export * from './expressions';
 export * from './query';
 export * from './utils';
+export * from './name-reference';
 export * from './closures/ClosureParser';
 export * from './closures/PrototypeMethodParser';
 export * from './closures/MathMethodParser';

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export * from './odata';
 export * from './expressions';
 export * from './query';
 export * from './utils';
+export * from './name-reference';
 export * from './closures/ClosureParser';
 export * from './closures/PrototypeMethodParser';
 export * from './closures/MathMethodParser';

--- a/src/name-reference.d.ts
+++ b/src/name-reference.d.ts
@@ -1,0 +1,6 @@
+
+export declare function isMethodOrNameReference(str: string): string;
+
+export declare function isNameReference(str: string): string;
+
+export declare function trimNameReference(str: string): string;

--- a/src/name-reference.js
+++ b/src/name-reference.js
@@ -1,5 +1,6 @@
 
 const REFERENCE_REGEXP = /^\$/;
+const NAME_REGEXP = /^(\$\w+)((\.(\w+))+)?$/
 
 /**
  * Returns true if the specified string is a method (e.g. $concat) or name reference (e.g. $dateCreated)
@@ -8,6 +9,22 @@ const REFERENCE_REGEXP = /^\$/;
  */
 function isMethodOrNameReference(str) {
     return REFERENCE_REGEXP.test(str)
+}
+
+/**
+ * @param {string} str 
+ * @returns {string}
+ */
+function isNameReference(str) {
+    return NAME_REGEXP.test(str)
+}
+
+/**
+ * @param {string} str 
+ * @returns {string}
+ */
+function trimNameReference(str) {
+    return str.replace(/^\$(\w+)/, '$1');
 }
 
 /**
@@ -45,6 +62,8 @@ function hasNameReference(str) {
 
 export {
     hasNameReference,
+    isNameReference,
+    trimNameReference,
     isMethodOrNameReference,
     getOwnPropertyWithNameRef
 }


### PR DESCRIPTION
This PR implements the usage of `$getField` expression for parsing field paths inside aggregated functions e.g.

```javascript
let query = new QueryExpression()
    .select({
        'maxPrice': {
            '$max': [
                {
                    '$round': [
                        {
                            '$getField': 'products.price'
                        },
                        2
                    ]
                }
            ]
        }
    }).from(Products).where('category').equal('Laptops');

```
> `SELECT MAX(ROUND("products"."price",2)) AS "maxPrice" FROM "ProductData" AS "products" WHERE ("category"='Laptops')`

Note: This operation is important when you are trying to use field path(s) as arguments of aggregated functions. The usage of a plain field path e.g. 

```json
"maxPrice": {
            "$max": [
                {
                    "$round": [
                        "$products.price",
                        2
                    ]
                }
            ]
        }
```
**is not allowed for security reasons**
