### PR TITLE
Validate corejs@3 preset env

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,12 +5,20 @@ module.exports = {
         [
             '@babel/preset-env',
             {
-                targets: {
-                    node: 'current'
-                }
+                useBuiltIns: 'entry',
+                corejs: 3
             }
         ]
     ],
     plugins: [
+        [
+            '@babel/plugin-transform-runtime',
+            {
+              'absoluteRuntime': false,
+              'corejs': false,
+              'helpers': true,
+              'regenerator': true
+            }
+          ]
     ]
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,14 @@ module.exports = {
                 corejs: 3
             }
         ]
+        // [
+        //     '@babel/preset-env',
+        //     {
+        //         targets: {
+        //             node: 'current'
+        //         }
+        //     }
+        // ]
     ],
     plugins: [
         [

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,21 +2,21 @@ module.exports = {
     sourceMaps: 'both',
     retainLines: true,
     presets: [
-        [
-            '@babel/preset-env',
-            {
-                useBuiltIns: 'entry',
-                corejs: 3
-            }
-        ]
         // [
         //     '@babel/preset-env',
         //     {
-        //         targets: {
-        //             node: 'current'
-        //         }
+        //         useBuiltIns: 'entry',
+        //         corejs: 3
         //     }
         // ]
+        [
+            '@babel/preset-env',
+            {
+                targets: {
+                    node: 'current'
+                }
+            }
+        ]
     ],
     plugins: [
         [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.10.4",
+      "version": "2.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/ClosureParser.spec.js
+++ b/spec/ClosureParser.spec.js
@@ -671,7 +671,7 @@ describe('ClosureParser', () => {
         });
     });
 
-    it('should use floor', async () => {
+    it('should use ceil', async () => {
         const Products = new QueryEntity('ProductData');
         let a = new QueryExpression().select( x => {
             x.name,

--- a/spec/OpenDataQuery.select.spec.js
+++ b/spec/OpenDataQuery.select.spec.js
@@ -213,16 +213,32 @@ describe('OpenDataQuery.select', () => {
     it('should select with destructured vars', () => {
         let query = new OpenDataQuery().from('Products');
         query.select((x) => {
-                const {id, name} = x;
+                const {id, name: productName} = x;
                 return {
                     id,
-                    name
+                    productName
                 }
             }).take(25);
         expect(query).toBeTruthy();
         const formatter = new OpenDataQueryFormatter();
         let result = formatter.formatSelect(query);
-        expect(result.$select).toEqual('id,name');
+        expect(result.$select).toEqual('id,name as productName');
+        expect(result.$top).toEqual(25);
+    });
+
+    it('should select with destructured nested vars', () => {
+        let query = new OpenDataQuery().from('Orders');
+        query.select((x) => {
+                const {id, orderedItem: { name: productName }} = x;
+                return {
+                    id,
+                    productName
+                }
+            }).take(25);
+        expect(query).toBeTruthy();
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result.$select).toEqual('id,orderedItem/name as productName');
         expect(result.$top).toEqual(25);
     });
 

--- a/spec/OpenDataQuery.select.spec.js
+++ b/spec/OpenDataQuery.select.spec.js
@@ -174,4 +174,56 @@ describe('OpenDataQuery.select', () => {
         expect(result.$top).toEqual(25);
     });
 
+    it('should select with vars', () => {
+        let query = new OpenDataQuery().from('Products');
+        query.select((x) => {
+                const id = x.id;
+                const name = x.name;
+                return {
+                    id,
+                    name
+                }
+            }).take(25);
+        expect(query).toBeTruthy();
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result.$select).toEqual('id,name');
+        expect(result.$top).toEqual(25);
+    });
+
+    it('should select with vars and method calls', () => {
+        let query = new OpenDataQuery().from('Products');
+        query.select((x) => {
+                const id = x.id;
+                const name = x.name;
+                const price = round(x.price, 2)
+                return {
+                    id,
+                    name,
+                    price
+                }
+            }).take(25);
+        expect(query).toBeTruthy();
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result.$select).toEqual('id,name,round(price,2) as price');
+        expect(result.$top).toEqual(25);
+    });
+
+    it('should select with destructured vars', () => {
+        let query = new OpenDataQuery().from('Products');
+        query.select((x) => {
+                const {id, name} = x;
+                return {
+                    id,
+                    name
+                }
+            }).take(25);
+        expect(query).toBeTruthy();
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result.$select).toEqual('id,name');
+        expect(result.$top).toEqual(25);
+    });
+
 });

--- a/spec/OpenDataQuery.select.spec.js
+++ b/spec/OpenDataQuery.select.spec.js
@@ -121,4 +121,57 @@ describe('OpenDataQuery.select', () => {
         expect(result.$select).toEqual('id,customer/familyName as customer,customer/address/streetAddress as streetAddress,orderedItem/name as orderedItem,orderDate');
         expect(result.$top).toEqual(25);
     });
+
+    it('should select with return statement', () => {
+        let query = new OpenDataQuery().from('Orders');
+        query.select((x) => {
+                return {
+                    id: x.id,
+                    customer: x.customer.familyName,
+                    streetAddress: x.customer.address.streetAddress,
+                    orderedItem: x.orderedItem.name,
+                    orderDate: x.orderDate
+                }
+            }).take(25);
+        expect(query).toBeTruthy();
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result.$select).toEqual('id,customer/familyName as customer,customer/address/streetAddress as streetAddress,orderedItem/name as orderedItem,orderDate');
+        expect(result.$top).toEqual(25);
+    });
+
+    it('should select with function', () => {
+        let query = new OpenDataQuery().from('Orders');
+        query.select(function(x) {
+                return {
+                    id: x.id,
+                    customer: x.customer.familyName,
+                    streetAddress: x.customer.address.streetAddress,
+                    orderedItem: x.orderedItem.name,
+                    orderDate: x.orderDate
+                }
+            }).take(25);
+        expect(query).toBeTruthy();
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result.$select).toEqual('id,customer/familyName as customer,customer/address/streetAddress as streetAddress,orderedItem/name as orderedItem,orderDate');
+        expect(result.$top).toEqual(25);
+    });
+
+    it('should select which returns object', () => {
+        let query = new OpenDataQuery().from('Orders');
+        query.select((x) => ({
+                    id: x.id,
+                    customer: x.customer.familyName,
+                    streetAddress: x.customer.address.streetAddress,
+                    orderedItem: x.orderedItem.name,
+                    orderDate: x.orderDate
+            })).take(25);
+        expect(query).toBeTruthy();
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result.$select).toEqual('id,customer/familyName as customer,customer/address/streetAddress as streetAddress,orderedItem/name as orderedItem,orderDate');
+        expect(result.$top).toEqual(25);
+    });
+
 });

--- a/spec/QueryExpression.where.spec.js
+++ b/spec/QueryExpression.where.spec.js
@@ -219,7 +219,7 @@ describe('QueryExpression.where', () => {
         });
     });
 
-    it('should use floor', async () => {
+    it('should use Math.floor', async () => {
         const Products = new QueryEntity('ProductData');
         let query = new QueryExpression()
             .select(({id, name, category, model, price}) => ({

--- a/spec/corejs-preset-env-select-object-destructuring.json
+++ b/spec/corejs-preset-env-select-object-destructuring.json
@@ -1,0 +1,216 @@
+{
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "UnaryExpression",
+                "operator": "void",
+                "argument": {
+                    "type": "FunctionExpression",
+                    "id": null,
+                    "params": [
+                        {
+                            "type": "Identifier",
+                            "name": "_ref23"
+                        }
+                    ],
+                    "body": {
+                        "type": "BlockStatement",
+                        "body": [
+                            {
+                                "type": "VariableDeclaration",
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "id"
+                                        },
+                                        "init": {
+                                            "type": "MemberExpression",
+                                            "computed": false,
+                                            "object": {
+                                                "type": "Identifier",
+                                                "name": "_ref23"
+                                            },
+                                            "property": {
+                                                "type": "Identifier",
+                                                "name": "id"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "name"
+                                        },
+                                        "init": {
+                                            "type": "MemberExpression",
+                                            "computed": false,
+                                            "object": {
+                                                "type": "Identifier",
+                                                "name": "_ref23"
+                                            },
+                                            "property": {
+                                                "type": "Identifier",
+                                                "name": "name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "category"
+                                        },
+                                        "init": {
+                                            "type": "MemberExpression",
+                                            "computed": false,
+                                            "object": {
+                                                "type": "Identifier",
+                                                "name": "_ref23"
+                                            },
+                                            "property": {
+                                                "type": "Identifier",
+                                                "name": "category"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "model"
+                                        },
+                                        "init": {
+                                            "type": "MemberExpression",
+                                            "computed": false,
+                                            "object": {
+                                                "type": "Identifier",
+                                                "name": "_ref23"
+                                            },
+                                            "property": {
+                                                "type": "Identifier",
+                                                "name": "model"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "price"
+                                        },
+                                        "init": {
+                                            "type": "MemberExpression",
+                                            "computed": false,
+                                            "object": {
+                                                "type": "Identifier",
+                                                "name": "_ref23"
+                                            },
+                                            "property": {
+                                                "type": "Identifier",
+                                                "name": "price"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "kind": "var"
+                            },
+                            {
+                                "type": "ReturnStatement",
+                                "argument": {
+                                    "type": "ObjectExpression",
+                                    "properties": [
+                                        {
+                                            "type": "Property",
+                                            "key": {
+                                                "type": "Identifier",
+                                                "name": "id"
+                                            },
+                                            "computed": false,
+                                            "value": {
+                                                "type": "Identifier",
+                                                "name": "id"
+                                            },
+                                            "kind": "init",
+                                            "method": false,
+                                            "shorthand": false
+                                        },
+                                        {
+                                            "type": "Property",
+                                            "key": {
+                                                "type": "Identifier",
+                                                "name": "name"
+                                            },
+                                            "computed": false,
+                                            "value": {
+                                                "type": "Identifier",
+                                                "name": "name"
+                                            },
+                                            "kind": "init",
+                                            "method": false,
+                                            "shorthand": false
+                                        },
+                                        {
+                                            "type": "Property",
+                                            "key": {
+                                                "type": "Identifier",
+                                                "name": "category"
+                                            },
+                                            "computed": false,
+                                            "value": {
+                                                "type": "Identifier",
+                                                "name": "category"
+                                            },
+                                            "kind": "init",
+                                            "method": false,
+                                            "shorthand": false
+                                        },
+                                        {
+                                            "type": "Property",
+                                            "key": {
+                                                "type": "Identifier",
+                                                "name": "model"
+                                            },
+                                            "computed": false,
+                                            "value": {
+                                                "type": "Identifier",
+                                                "name": "model"
+                                            },
+                                            "kind": "init",
+                                            "method": false,
+                                            "shorthand": false
+                                        },
+                                        {
+                                            "type": "Property",
+                                            "key": {
+                                                "type": "Identifier",
+                                                "name": "price"
+                                            },
+                                            "computed": false,
+                                            "value": {
+                                                "type": "Identifier",
+                                                "name": "price"
+                                            },
+                                            "kind": "init",
+                                            "method": false,
+                                            "shorthand": false
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "generator": false,
+                    "expression": false,
+                    "async": false
+                },
+                "prefix": true
+            }
+        }
+    ],
+    "sourceType": "script"
+}

--- a/spec/nodejs-preset-env-select-object-destructuring.json
+++ b/spec/nodejs-preset-env-select-object-destructuring.json
@@ -1,0 +1,183 @@
+{
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "UnaryExpression",
+                "operator": "void",
+                "argument": {
+                    "type": "ArrowFunctionExpression",
+                    "id": null,
+                    "params": [
+                        {
+                            "type": "ObjectPattern",
+                            "properties": [
+                                {
+                                    "type": "Property",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "id"
+                                    },
+                                    "computed": false,
+                                    "value": {
+                                        "type": "Identifier",
+                                        "name": "id"
+                                    },
+                                    "kind": "init",
+                                    "method": false,
+                                    "shorthand": true
+                                },
+                                {
+                                    "type": "Property",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "name"
+                                    },
+                                    "computed": false,
+                                    "value": {
+                                        "type": "Identifier",
+                                        "name": "name"
+                                    },
+                                    "kind": "init",
+                                    "method": false,
+                                    "shorthand": true
+                                },
+                                {
+                                    "type": "Property",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "category"
+                                    },
+                                    "computed": false,
+                                    "value": {
+                                        "type": "Identifier",
+                                        "name": "category"
+                                    },
+                                    "kind": "init",
+                                    "method": false,
+                                    "shorthand": true
+                                },
+                                {
+                                    "type": "Property",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "model"
+                                    },
+                                    "computed": false,
+                                    "value": {
+                                        "type": "Identifier",
+                                        "name": "model"
+                                    },
+                                    "kind": "init",
+                                    "method": false,
+                                    "shorthand": true
+                                },
+                                {
+                                    "type": "Property",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "price"
+                                    },
+                                    "computed": false,
+                                    "value": {
+                                        "type": "Identifier",
+                                        "name": "price"
+                                    },
+                                    "kind": "init",
+                                    "method": false,
+                                    "shorthand": true
+                                }
+                            ]
+                        }
+                    ],
+                    "body": {
+                        "type": "ObjectExpression",
+                        "properties": [
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "id"
+                                },
+                                "computed": false,
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "id"
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": true
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "name"
+                                },
+                                "computed": false,
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "name"
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": true
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "category"
+                                },
+                                "computed": false,
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "category"
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": true
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "model"
+                                },
+                                "computed": false,
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "model"
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": true
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "price"
+                                },
+                                "computed": false,
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "price"
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": true
+                            }
+                        ]
+                    },
+                    "generator": false,
+                    "expression": true,
+                    "async": false
+                },
+                "prefix": true
+            }
+        }
+    ],
+    "sourceType": "script"
+}

--- a/src/open-data-query.expression.d.ts
+++ b/src/open-data-query.expression.d.ts
@@ -8,3 +8,5 @@ export declare class OpenDataQuery extends QueryExpression {
 }
 
 export function any<T>(expr:string | ((value: T) => any)): OpenDataQuery;
+
+export function anyOf<T>(expr:string | ((value: T) => any)): OpenDataQuery;

--- a/src/open-data-query.expression.js
+++ b/src/open-data-query.expression.js
@@ -65,7 +65,12 @@ function any(expr) {
     return result;
 }
 
+function anyOf(expr) {
+    return any(expr)
+}
+
 export {
     any,
+    anyOf,
     OpenDataQuery
 }


### PR DESCRIPTION
This PR validates and fixes closure parser while `@babel/preset-env` enables `corejs@3`.