### PR TITLE
Use query entity on insert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/QueryExpression.delete.spec.js
+++ b/spec/QueryExpression.delete.spec.js
@@ -1,0 +1,51 @@
+import { QueryEntity, QueryExpression, SqlFormatter } from '../src/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+
+describe('SqlFormatter', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll((done) => {
+        if (db) {
+            db.close();
+            return done();
+        }
+    });
+
+    it('should create delete statement', () => {
+
+        const query = new QueryExpression()
+            .delete('Table1').where('id').equal(124);
+
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('DELETE FROM Table1 WHERE (id=124)');
+
+    });
+
+    it('should create delete statement with query entity', () => {
+
+        const query = new QueryExpression()
+            .delete(new QueryEntity('Table1')).where('id').equal(124);
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('DELETE FROM Table1 WHERE (id=124)');
+
+    });
+
+    it('should create delete statement with query entity and alias', () => {
+
+        const query = new QueryExpression()
+            .delete(new QueryEntity('Table1').as('MyTable')).where('id').equal(124);
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('DELETE FROM Table1 WHERE (id=124)');
+
+    });
+
+});

--- a/spec/QueryExpression.insert.spec.js
+++ b/spec/QueryExpression.insert.spec.js
@@ -1,0 +1,69 @@
+import { QueryEntity, QueryExpression, SqlFormatter } from '../src/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+
+describe('SqlFormatter', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll((done) => {
+        if (db) {
+            db.close();
+            return done();
+        }
+    });
+
+    it('should create insert statement', () => {
+
+        const query = new QueryExpression()
+            .insert({
+                id: 1451,
+                name: 'New Product',
+                model: 'NP800',
+                price: 505.5
+            })
+            .into('Table1');
+
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('INSERT INTO Table1(id, name, model, price) VALUES (1451, \'New Product\', \'NP800\', 505.5)');
+
+    });
+
+    it('should create insert statement with query entity', () => {
+
+        const query = new QueryExpression()
+            .insert({
+                id: 1451,
+                name: 'New Product',
+                model: 'NP800',
+                price: 505.5
+            })
+            .into(new QueryEntity('Table1'));
+
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('INSERT INTO Table1(id, name, model, price) VALUES (1451, \'New Product\', \'NP800\', 505.5)');
+    });
+
+    it('should create insert statement with query entity and alias', () => {
+
+        const query = new QueryExpression()
+            .insert({
+                id: 1451,
+                name: 'New Product',
+                model: 'NP800',
+                price: 505.5
+            })
+            .into(new QueryEntity('Table1').as('MyTable'));
+
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('INSERT INTO Table1(id, name, model, price) VALUES (1451, \'New Product\', \'NP800\', 505.5)');
+    });
+
+});

--- a/spec/QueryExpression.update.spec.js
+++ b/spec/QueryExpression.update.spec.js
@@ -1,0 +1,59 @@
+import { QueryEntity, QueryExpression, SqlFormatter } from '../src/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+
+describe('SqlFormatter', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll((done) => {
+        if (db) {
+            db.close();
+            return done();
+        }
+    });
+
+    it('should create update statement', () => {
+
+        const query = new QueryExpression()
+            .update('Table1').set({
+                price: 500
+            }).where('id').equal(124);
+
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('UPDATE Table1 SET price=500 WHERE (id=124)');
+
+    });
+
+    it('should create update statement with query entity', () => {
+
+        const query = new QueryExpression()
+            .update(new QueryEntity('Table1')).set({
+                price: 500
+            }).where('id').equal(124);
+
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('UPDATE Table1 SET price=500 WHERE (id=124)');
+
+    });
+
+    it('should create update statement with query entity and alias', () => {
+
+        const query = new QueryExpression()
+            .update(new QueryEntity('Table1').as('MyTable')).set({
+                price: 500
+            }).where('id').equal(124);
+
+        const sql = new SqlFormatter().format(query);
+        expect(sql).toEqual('UPDATE Table1 SET price=500 WHERE (id=124)');
+
+    });
+
+});

--- a/src/query.d.ts
+++ b/src/query.d.ts
@@ -54,9 +54,12 @@ export declare class QueryExpression {
     where(expr: string | any): this;
     injectWhere(where: any): void;
     delete(entity: string): this;
+    delete(entity: QueryEntity): this;
     insert(obj: any): this;
     into(entity: string): this;
+    into(entity: QueryEntity): this;
     update(entity: string): this;
+    update(entity: QueryEntity): this;
     set(obj: any): this;
     select<T>(expr: QueryFunc<T>, params?: any): this;
     select<T,J>(expr: QueryJoinFunc<T, J>, params?: any): this;

--- a/src/query.js
+++ b/src/query.js
@@ -297,13 +297,23 @@ class QueryExpression {
     }
     /**
      * Initializes a "delete" query and sets the entity name that is going to be used in this query.
-     * @param entity {string}
+     * @param entity {string|QueryEntity}
      * @returns {QueryExpression}
      */
     delete(entity) {
-        if (isNil(entity))
-            return this;
-        this.$delete = entity.valueOf();
+        if (entity == null) {
+            throw new Error('Entity cannot be empty at this context');
+        }
+        // get collection name (which can be string or QueryEntity)
+        let name;
+        if (instanceOf(entity, QueryEntity)) {
+            name = entity.name;
+        } else if (typeof entity === 'string') {
+            name = entity;
+        } else {
+            throw new TypeError(`Expected string or an instance of QueryEntity class. Got ${typeof entity}`)
+        }
+        this.$delete = name;
         //delete other properties (if any)
         delete this.$insert;
         delete this.$select;
@@ -330,35 +340,59 @@ class QueryExpression {
             throw new Error('Invalid argument. Object must be an object or an array of objects');
         }
     }
+    /**
+     * @param {string|QueryEntity} entity
+     */
     into(entity) {
-        if (isNil(entity))
-            return this;
+        if (entity == null) {
+            throw new Error('Entity cannot be empty at this context');
+        }
+        // get collection name (which can be string or QueryEntity)
+        let name;
+        if (instanceOf(entity, QueryEntity)) {
+            name = entity.name;
+        } else if (typeof entity === 'string') {
+            name = entity;
+        } else {
+            throw new TypeError(`Expected string or an instance of QueryEntity class. Got ${typeof entity}`)
+        }
         if (isNil(this.$insert))
             return this;
+        // get current property of $insert
         let prop = Object.key(this.$insert);
         if (isNil(prop))
             return this;
-        if (prop === entity)
+        if (prop === name)
             return this;
         let value = this.$insert[prop];
         if (isNil(value))
             return this;
-        this.$insert[entity] = value;
+        // set object to insert
+        this.$insert[name] = value;
+        // remove unused property
         delete this.$insert[prop];
         return this;
     }
     /**
      * Initializes an update query and sets the entity name that is going to be used in this query.
-     * @param {string} entity
+     * @param {string|QueryEntity} entity
      * @returns {QueryExpression}
      */
     update(entity) {
-        if (isNil(entity))
-            return this;
-        if (typeof entity !== 'string')
-            throw new Error('Invalid argument type. Update entity argument must be a string.');
+        if (entity == null) {
+            throw new Error('Entity cannot be empty at this context');
+        }
+        // get collection name (which can be string or QueryEntity)
+        let name;
+        if (instanceOf(entity, QueryEntity)) {
+            name = entity.name;
+        } else if (typeof entity === 'string') {
+            name = entity;
+        } else {
+            throw new TypeError(`Expected string or an instance of QueryEntity class. Got ${typeof entity}`)
+        }
         this.$update = {};
-        this.$update[entity] = {};
+        this.$update[name] = {};
         //delete other properties (if any)
         delete this.$delete;
         delete this.$select;


### PR DESCRIPTION
This PR enables the usage of an instance of QueryEntity class on `QueryExpression.update(entity)`, `QueryExpression.into(entity)` and `QueryExpression.delete(entity)` methods.