### PR TITLE
add object name validator as property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.11.2",
+      "version": "2.11.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/formatter.d.ts
+++ b/src/formatter.d.ts
@@ -1,4 +1,5 @@
 // MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP All rights reserved
+import { ObjectNameValidator } from './object-name.validator';
 import {QueryExpression, QueryField, QueryValueRef} from "./query";
 
 export declare interface FormatterSettings {
@@ -10,6 +11,7 @@ export declare interface FormatterSettings {
 export declare class SqlFormatter {
     provider: any;
     settings: FormatterSettings;
+    get validator(): ObjectNameValidator;
 
     escape(value: any,unquoted?: boolean): string | any;
     escapeConstant(value: any,unquoted?: boolean): string | any;

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -986,8 +986,16 @@ class SqlFormatter {
         if (isNameReference(str)) {
             str = trimNameReference(name);
         }
-        return ObjectNameValidator.validator.escape(str, this.settings.nameFormat);
+        return this.validator.escape(str, this.settings.nameFormat);
     }
+
+    /**
+     * @returns {ObjectNameValidator}
+     */
+    get validator() {
+        return ObjectNameValidator.validator;
+    }
+
     /**
      * @param obj {QueryField}
      * @param format {string}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,7 @@ export * from './closures/PrototypeMethodParser';
 export * from './closures/MathMethodParser';
 export * from './closures/DateMethodParser';
 export * from './closures/StringMethodParser';
+export * from './object-name.validator';
 export * from './open-data-query.expression';
 export * from './open-data-query.formatter';
 


### PR DESCRIPTION
This PR adds `SqlFormatter.validator` property  for allowing `SqlFormatter`'s subclasses to override the default `ObjectNameValidator`.