### PR TITLE
Set object name validator event

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,10 @@
+engines:
+  duplication:
+    exclude_paths:
+      - "docs/**"
+      - "spec/**/*"
+exclude_paths:
+  - "docs/**"
+  - "spec/**/*"
+  - ".github/**/*"
+  - "babel.config.js"

--- a/.npmignore
+++ b/.npmignore
@@ -34,3 +34,6 @@ tsconfig.json
 
 # gitpod
 .gitpod.yml
+
+# codacy
+.codacy.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/SimpleQueryFormatter.spec.js
+++ b/spec/SimpleQueryFormatter.spec.js
@@ -1,0 +1,125 @@
+import {SqlFormatter, QueryExpression, ObjectNameValidator, QueryEntity, QueryField} from '../src/index';
+
+const TRIM_QUALIFIED_NAME_REGEXP = /^(\w+)((\.(\w+))+)/;
+const TRIM_SAME_ALIAS_REGEXP = /^(.*)\sAS\s(.*)$/;
+
+class SimpleObjectNameValidator extends ObjectNameValidator {
+    constructor() {
+        super();
+    }
+    test(name, qualified, throwError) {
+        return super.test(name, true, throwError);
+    }
+}
+
+class SimpleSqlFormatter extends SqlFormatter {
+    _validator = new SimpleObjectNameValidator();
+    constructor(options) {
+        super();
+        this.settings = Object.assign({
+            nameFormat: '$1',
+            forceAlias: false
+        }, options);
+    }
+    get validator() {
+        return this._validator;
+    }
+
+    /**
+     * @param {*} name
+     * @returns {string}
+     */
+    escapeName(name) {
+        if (typeof name === 'object' && Object.prototype.hasOwnProperty.call(name, '$name')) {
+            return this.escapeName(name.$name);
+        }
+        if (typeof name !== 'string') {
+            throw new Error('Invalid name expression. Expected string.');
+        }
+        const matches = TRIM_QUALIFIED_NAME_REGEXP.exec(name);
+        if (matches) {
+            return this.escapeName(matches[matches.length - 1]);
+        }
+        return super.escapeName(name);
+    }
+
+    escapeEntity(name) {
+        return super.escapeEntity(name);
+    }
+
+    formatFieldEx(field, format) {
+        if (Object.prototype.hasOwnProperty.call(field, '$name')) {
+            const { $name: name } = field;
+            const matches = TRIM_QUALIFIED_NAME_REGEXP.exec(name);
+            if (matches) {
+                return this.escapeName(matches[matches.length - 1]);
+            }
+        }
+        const result = super.formatFieldEx(field, format);
+        const matches = TRIM_SAME_ALIAS_REGEXP.exec(result);
+        if (matches && matches[1] === matches[2]) {
+            return matches[1];
+        }
+        return result;
+    }
+}
+
+
+describe('SimpleQueryFormatter', () => {
+    beforeAll(() => {
+        ObjectNameValidator.use(new SimpleObjectNameValidator());
+    });
+    afterAll(() => {
+        ObjectNameValidator.use(new ObjectNameValidator());
+    });
+    it('should create a simple select expression', () => {
+        const query = new QueryExpression().select('id', 'name', 'category').from('ProductData');
+        const formatter = new SimpleSqlFormatter();
+        const sql = formatter.formatSelect(query);
+        expect(sql).toBe('SELECT id, name, category FROM ProductData');
+    });
+    it('should select from table with qualified name', () => {
+
+        const query = new QueryExpression().select('id', 'name', 'category').from('dbo.ProductData');
+        const formatter = new SimpleSqlFormatter();
+        const sql = formatter.formatSelect(query);
+        expect(sql).toBe('SELECT id, name, category FROM dbo.ProductData');
+    });
+
+    it('should select from entity with qualified name', () => {
+
+        let query = new QueryExpression().select('id', 'name', 'category').from(new QueryEntity('dbo.ProductData'));
+        const formatter = new SimpleSqlFormatter();
+        let sql = formatter.formatSelect(query);
+        expect(sql).toBe('SELECT id, name, category FROM dbo.ProductData');
+        query = new QueryExpression().select(
+            new QueryField('id'),
+            new QueryField('name'),
+            new QueryField('category')
+        ).from(new QueryEntity('dbo.ProductData'));
+        sql = formatter.formatSelect(query);
+        expect(sql).toBe('SELECT id, name, category FROM dbo.ProductData');
+
+    });
+
+    it('should select by using query fields', () => {
+        const formatter = new SimpleSqlFormatter();
+        const query = new QueryExpression().select(
+            new QueryField('id'),
+            new QueryField('name'),
+            new QueryField('category')
+        ).from(new QueryEntity('dbo.ProductData'));
+        const sql = formatter.formatSelect(query);
+        expect(sql).toBe('SELECT id, name, category FROM dbo.ProductData');
+    });
+
+    it('should select by using closures', () => {
+        const formatter = new SimpleSqlFormatter();
+        const Products = new QueryEntity('dbo.Products');
+        const query = new QueryExpression().select(({id, name, category}) => {
+            return {id, name, category};
+        }).from(Products);
+        const sql = formatter.formatSelect(query);
+        expect(sql).toBe('SELECT id, name, category FROM dbo.Products');
+    });
+});

--- a/spec/SimpleQueryFormatter.spec.js
+++ b/spec/SimpleQueryFormatter.spec.js
@@ -3,17 +3,8 @@ import {SqlFormatter, QueryExpression, ObjectNameValidator, QueryEntity, QueryFi
 const TRIM_QUALIFIED_NAME_REGEXP = /^(\w+)((\.(\w+))+)/;
 const TRIM_SAME_ALIAS_REGEXP = /^(.*)\sAS\s(.*)$/;
 
-class SimpleObjectNameValidator extends ObjectNameValidator {
-    constructor() {
-        super();
-    }
-    test(name, qualified, throwError) {
-        return super.test(name, true, throwError);
-    }
-}
-
 class SimpleSqlFormatter extends SqlFormatter {
-    _validator = new SimpleObjectNameValidator();
+    // _validator = new SimpleObjectNameValidator();
     constructor(options) {
         super();
         this.settings = Object.assign({
@@ -21,9 +12,9 @@ class SimpleSqlFormatter extends SqlFormatter {
             forceAlias: false
         }, options);
     }
-    get validator() {
-        return this._validator;
-    }
+    // get validator() {
+    //     return this._validator;
+    // }
 
     /**
      * @param {*} name
@@ -66,11 +57,16 @@ class SimpleSqlFormatter extends SqlFormatter {
 
 
 describe('SimpleQueryFormatter', () => {
+    const onValidateName = (event) => {
+        // validate database object name by allowing qualified names e.g. dbo.Products
+        event.valid = ObjectNameValidator.validator.test(event.name, true);
+    };
     beforeAll(() => {
-        ObjectNameValidator.use(new SimpleObjectNameValidator());
+        ObjectNameValidator.validator.validating.subscribe(onValidateName);
     });
     afterAll(() => {
-        ObjectNameValidator.use(new ObjectNameValidator());
+        //
+        ObjectNameValidator.validator.validating.unsubscribe(onValidateName);
     });
     it('should create a simple select expression', () => {
         const query = new QueryExpression().select('id', 'name', 'category').from('ProductData');

--- a/src/formatter.d.ts
+++ b/src/formatter.d.ts
@@ -11,12 +11,10 @@ export declare interface FormatterSettings {
 export declare class SqlFormatter {
     provider: any;
     settings: FormatterSettings;
-    get validator(): ObjectNameValidator;
-
+    
     escape(value: any,unquoted?: boolean): string | any;
     escapeConstant(value: any,unquoted?: boolean): string | any;
     
-
     $or(...arg:any[]): string;
     $and(...arg:any[]): string;
     $not(arg:any): string;

--- a/src/formatter.d.ts
+++ b/src/formatter.d.ts
@@ -82,6 +82,7 @@ export declare class SqlFormatter {
     formatUpdate(query: QueryExpression | any): any;
     formatDelete(query: QueryExpression | any): any;
     escapeName(name: string): any;
+    escapeEntity(name: string): any;
     formatFieldEx(obj: any, format: string): any;
     format(obj: any, s?: string): any;
 

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -699,15 +699,15 @@ class SqlFormatter {
             let entityRef = obj.$ref[entity];
             //escape entity ref
             if (instanceOf(entityRef, QueryExpression)) {
-                escapedEntity = '(' + this.format(entityRef) + ') ' + $this.escapeName(entity);
+                escapedEntity = '(' + this.format(entityRef) + ') ' + $this.escapeEntity(entity);
             }
             else {
-                escapedEntity = entityRef.$as ? $this.escapeName(entityRef.name) + getAliasKeyword.bind($this)() + $this.escapeName(entityRef.$as) : $this.escapeName(entityRef.name);
+                escapedEntity = entityRef.$as ? $this.escapeEntity(entityRef.name) + getAliasKeyword.bind($this)() + $this.escapeName(entityRef.$as) : $this.escapeEntity(entityRef.name);
             }
         }
         else {
             //escape entity name
-            escapedEntity = $this.escapeName(entity);
+            escapedEntity = $this.escapeEntity(entity);
         }
         //add basic SELECT statement
         if (Object.prototype.hasOwnProperty.call(obj, '$fixed') && obj.$fixed === true) {
@@ -737,7 +737,7 @@ class SqlFormatter {
                 else {
                     //get join table name
                     table = Object.key(x.$entity);
-                    sql = sql.concat(' ' + joinType + ' JOIN ').concat($this.escapeName(table));
+                    sql = sql.concat(' ' + joinType + ' JOIN ').concat($this.escapeEntity(table));
                     //add alias
                     if (x.$entity.$as)
                         sql = sql.concat(getAliasKeyword.bind($this)()).concat($this.escapeName(x.$entity.$as));
@@ -920,7 +920,7 @@ class SqlFormatter {
         for (let prop in obj1)
             if (Object.prototype.hasOwnProperty.call(obj1, prop))
                 props.push(prop);
-        sql = sql.concat('INSERT INTO ', self.escapeName(entity), '(', map(props, function (x) { return self.escapeName(x); }).join(', '), ') VALUES (',
+        sql = sql.concat('INSERT INTO ', self.escapeEntity(entity), '(', map(props, function (x) { return self.escapeName(x); }).join(', '), ') VALUES (',
             map(props, function (x) {
                 let value = obj1[x];
                 return self.escape(value !== null ? value : null);
@@ -945,7 +945,7 @@ class SqlFormatter {
             if (Object.prototype.hasOwnProperty.call(obj1, prop))
                 props.push(prop);
         //add basic INSERT statement
-        sql = sql.concat('UPDATE ', self.escapeName(entity), ' SET ',
+        sql = sql.concat('UPDATE ', self.escapeEntity(entity), ' SET ',
             map(props, function (x) {
                 let value = obj1[x];
                 return self.escapeName(x).concat('=', self.escape(value !== null ? value : null));
@@ -967,7 +967,7 @@ class SqlFormatter {
         //get entity name
         let entity = expr.$delete;
         //add basic INSERT statement
-        sql = sql.concat('DELETE FROM ', this.escapeName(entity));
+        sql = sql.concat('DELETE FROM ', this.escapeEntity(entity));
         if (expr.$where != null) {
             sql = sql.concat(' WHERE ', this.formatWhere(expr.$where));
         }
@@ -981,6 +981,17 @@ class SqlFormatter {
         // throw error for unexpected type
         if (typeof name !== 'string') {
             throw new Error('Invalid name expression. Expected string.');
+        }
+        let str = name;
+        if (isNameReference(str)) {
+            str = trimNameReference(name);
+        }
+        return this.validator.escape(str, this.settings.nameFormat);
+    }
+
+    escapeEntity(name) {
+        if (typeof name !== 'string') {
+            throw new Error('Invalid entity expression. Expected string.');
         }
         let str = name;
         if (isNameReference(str)) {

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -986,7 +986,7 @@ class SqlFormatter {
         if (isNameReference(str)) {
             str = trimNameReference(name);
         }
-        return this.validator.escape(str, this.settings.nameFormat);
+        return ObjectNameValidator.validator.escape(str, this.settings.nameFormat);
     }
 
     escapeEntity(name) {
@@ -997,14 +997,7 @@ class SqlFormatter {
         if (isNameReference(str)) {
             str = trimNameReference(name);
         }
-        return this.validator.escape(str, this.settings.nameFormat);
-    }
-
-    /**
-     * @returns {ObjectNameValidator}
-     */
-    get validator() {
-        return ObjectNameValidator.validator;
+        return ObjectNameValidator.validator.escape(str, this.settings.nameFormat);
     }
 
     /**

--- a/src/object-name.validator.d.ts
+++ b/src/object-name.validator.d.ts
@@ -1,3 +1,5 @@
+import {SyncSeriesEventEmitter} from '@themost/events';
+
 export declare class ObjectNameValidator {
 
     static Patterns: {
@@ -12,6 +14,8 @@ export declare class ObjectNameValidator {
     static readonly validator: ObjectNameValidator;
 
     static use(validator: ObjectNameValidator): void;
+    
+    validating: SyncSeriesEventEmitter<{ name: string, qualified?: boolean, valid?: boolean }>
 
     constructor(pattern?: string);
 
@@ -20,6 +24,8 @@ export declare class ObjectNameValidator {
     qualifiedPattern: RegExp;
 
     test(name: string, qualified?: boolean, throwError?: boolean): boolean;
+
+    exec(name: string, qualified?: boolean): boolean;
 
     escape(name: string, format?: string): string;
 }

--- a/src/object-name.validator.js
+++ b/src/object-name.validator.js
@@ -1,6 +1,3 @@
-/*eslint-env es6 */
-// eslint-disable-next-line no-unused-vars
-
 import {SyncSeriesEventEmitter} from '@themost/events';
 
 class InvalidObjectNameError extends Error {

--- a/src/object-name.validator.js
+++ b/src/object-name.validator.js
@@ -1,6 +1,8 @@
 /*eslint-env es6 */
 // eslint-disable-next-line no-unused-vars
 
+import {SyncSeriesEventEmitter} from '@themost/events';
+
 class InvalidObjectNameError extends Error {
     /**
      * @param {string=} msg
@@ -29,6 +31,8 @@ class ObjectNameValidator {
          * @type {RegExp}
          */
         this.qualifiedPattern = new RegExp(`^\\*$|^${this.pattern.source}((\\.)${this.pattern.source})*(\\.\\*)?$`);
+
+        this.validating = new SyncSeriesEventEmitter();
     }
     /**
      * @param {string} name - A string which defines a query field name or an alias
@@ -53,6 +57,36 @@ class ObjectNameValidator {
         }
         return valid;
     }
+
+    /**
+     * @param {string} name
+     * @param {boolean=} qualified
+     * @returns {boolean}
+     */
+    exec(name, qualified) {
+        let valid = undefined;
+        // validating event allow third party subscribers to validate object names
+        // and return a boolean value which indicates whether the object name is valid or not
+        const validatingEvent = {
+            name,
+            qualified,
+            valid
+        };
+        // raise validating event
+        this.validating.emit(validatingEvent);
+        // if valid property is boolean and has been set
+        if (typeof validatingEvent.valid === 'boolean') {
+            // throw error if name is invalid
+            if (validatingEvent.valid === false) {
+                throw new InvalidObjectNameError();
+            }
+            // otherwise, return the result
+            return validatingEvent.valid;
+        }
+        // this a fallback mechanism where the validating event has not been handled
+        return this.test(name, qualified);
+    }
+
     /**
      * Escapes the given base on the format provided
      * @param {string} name - The object name
@@ -60,7 +94,7 @@ class ObjectNameValidator {
      */
     escape(name, format) {
         // validate qualified object name
-        this.test(name);
+        this.exec(name);
         const pattern = new RegExp(this.pattern.source, 'g');
         return name.replace(pattern, format || '$1');
     }

--- a/src/query.js
+++ b/src/query.js
@@ -1638,7 +1638,7 @@ class QueryField {
         if (fromEntity == null) {
             throw new Error('Invalid argument. Expected a valid instance of query entity or string.');
         }
-        ObjectNameValidator.validator.test(fromEntity, false);
+        ObjectNameValidator.validator.exec(fromEntity, false);
         // get property
         if (this.$name != null) {
             if (typeof this.$name === 'string') {
@@ -1789,7 +1789,7 @@ class QueryField {
         }
         if (typeof alias !== 'string')
             throw new Error('Invalid argument. Expected string');
-        ObjectNameValidator.validator.test(alias, false);
+        ObjectNameValidator.validator.exec(alias, false);
         //get first property
         let prop = Object.key(this);
         if (isNil(prop))


### PR DESCRIPTION
This PR adds a new event `ObjectNameValidator.validating` for allowing third party subscribers to validate object names. This operation is important when you want to override the default behaviour of `ObjectNameValidator` class e.g.

Database tables are being accessed by using qualified names e.g. `dbo.Products`. The default behaviour does not allow the usage of qualified names during this process. Use `ObjectNameValidator.validator.validating` event and validate qualified names

```javascript
import {SqlFormatter, QueryExpression, ObjectNameValidator, QueryEntity} from '@themost/query';

ObjectNameValidator.validator.validating.subscribe((event) => {
        // validate database object name by allowing qualified names e.g. dbo.Products
        event.valid = ObjectNameValidator.validator.test(event.name, true);
});

const formatter = new SqlFormatter();
const Products = new QueryEntity('dbo.Products');
const query = new QueryExpression().select(({id, name, category}) => {
    return {id, name, category};
}).from(Products);
const sql = formatter.formatSelect(query);
```

