### PR TITLE
handle member expession

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/ResolvingMember.spec.js
+++ b/spec/ResolvingMember.spec.js
@@ -1,0 +1,56 @@
+import { LiteralExpression, MemberExpression, MethodCallExpression, QueryEntity, QueryExpression, QueryField } from '../src/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+import { MemoryFormatter } from './test/TestMemoryFormatter';
+
+describe('ResolvingMember', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter();
+    });
+    afterAll(async () => {
+        if (db) {
+            await db.closeAsync();
+        }
+    });
+    
+    it('should resolve custom member', async () => {
+        const orders = new QueryEntity('OrderData');
+        const people = new QueryEntity('PersonData');
+        const q = new QueryExpression();
+        q.resolvingMember.subscribe((event) => {
+            if (typeof event.member === 'string') {
+                const member = event.member.split('.');
+                const [,field] = member;
+                if (field === 'orderCustomer') {
+                    event.member = new MethodCallExpression('concat', [
+                        new QueryField('givenName').from(people),
+                        new LiteralExpression(' '),
+                        new QueryField('familyName').from(people),
+                    ])
+                }
+            }
+        })
+        q.select(
+            ({id, orderCustomer}) => {
+                return {
+                    id,
+                    orderCustomer
+                }
+            }
+        ).from(orders)
+        .join(people).with((x, {id}) => x.customer === id, people)
+        .orderBy(
+            ({customer}) => customer
+        ).take(10);
+        const items = await db.executeAsync(q);
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            expect(item.orderCustomer).toBeTruthy();
+        }
+    });
+
+});

--- a/src/closures/ClosureParser.d.ts
+++ b/src/closures/ClosureParser.d.ts
@@ -1,5 +1,6 @@
 // MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP All rights reserved
 import {SyncSeriesEventEmitter} from '@themost/events';
+import { Expression } from '../expressions';
 
 export type SelectClosure = (x: any, ...params: any[]) => any;
 export type FilterClosure = (x: any, ...params: any[]) => any;
@@ -28,7 +29,7 @@ export declare class ClosureParser {
     parseMethod(expr: any): any;
     parseIdentifier(expr: any): any;
     parseLiteral(expr: any): any;
-    resolvingMember: SyncSeriesEventEmitter<{ target: any, member: string }>;
-    resolvingJoinMember: SyncSeriesEventEmitter<{ target: any, object: string, member: string, fullyQualifiedMember?: string }>;
+    resolvingMember: SyncSeriesEventEmitter<{ target: any, member: string | Expression }>;
+    resolvingJoinMember: SyncSeriesEventEmitter<{ target: any, object: string, member: string | Expression, fullyQualifiedMember?: string }>;
     resolvingMethod: SyncSeriesEventEmitter<{ target: any, method: string }>;
 }

--- a/src/closures/ClosureParser.js
+++ b/src/closures/ClosureParser.js
@@ -2,7 +2,8 @@
 import {
     LiteralExpression, ObjectExpression, Operators, SequenceExpression,
     MemberExpression, ArithmeticExpression, LogicalExpression,
-    AggregateComparisonExpression, MethodCallExpression, ComparisonExpression
+    AggregateComparisonExpression, MethodCallExpression, ComparisonExpression,
+    Expression
 } from '../expressions';
 const isComparisonOperator = ComparisonExpression.isComparisonOperator;
 const isArithmeticOperator = ArithmeticExpression.isArithmeticOperator;
@@ -806,6 +807,10 @@ class ClosureParser {
                     // otherwise resolve member of joined collection
                     self.resolvingJoinMember.emit(event);
                 }
+                // #handle-event-member
+                if (event.member instanceof Expression) {
+                    return event.member;
+                }
                 // if event.object is not null
                 if (event.object != null) {
                     // concat member expression e.g. new MemberExpression(address.id)
@@ -857,6 +862,10 @@ class ClosureParser {
                         fullyQualifiedMember: fullyQualifiedMember
                     };
                     this.resolvingJoinMember.emit(event);
+                    // #handle-event-member
+                    if (event.member instanceof Expression) {
+                        return event.member;
+                    }
                     return new MemberExpression(event.object + '.' + event.member);
                 }
                 else {
@@ -892,6 +901,10 @@ class ClosureParser {
                     alias = null;
                 }
                 self.resolvingMember.emit(memberEvent);
+                // #handle-event-member
+                if (memberEvent.member instanceof Expression) {
+                    return memberEvent.member;
+                }
                 return new MemberExpression(memberEvent.member);
             } else {
                 let findQualifiedMember;
@@ -964,6 +977,10 @@ class ClosureParser {
                         fullyQualifiedMember: memberPath.join('.')
                     }
                     self.resolvingJoinMember.emit(memberEvent);
+                    // #handle-event-member
+                    if (memberEvent.member instanceof Expression) {
+                        return memberEvent.member;
+                    }
                     if (memberEvent.object != null) {
                         // concat member expression e.g. new MemberExpression(address.id)
                         return new MemberExpression(memberEvent.object + '.' + memberEvent.member);

--- a/src/expressions.d.ts
+++ b/src/expressions.d.ts
@@ -4,6 +4,11 @@ export declare interface ExpressionBase {
     source?: string;
 }
 
+export declare abstract class Expression implements ExpressionBase {
+    exprOf(): any;
+    source?: string;
+}
+
 export declare interface SelectExpressionBase extends ExpressionBase {
     as?: string;
 }
@@ -28,7 +33,7 @@ export declare const Operators: {
     BitAnd: string
 }
 
-export declare class ArithmeticExpression implements ExpressionBase {
+export declare class ArithmeticExpression extends Expression {
 
     static isArithmeticOperator(op: string): boolean;
 
@@ -36,12 +41,12 @@ export declare class ArithmeticExpression implements ExpressionBase {
     exprOf(): any;
 }
 
-export declare class MemberExpression implements ExpressionBase {
+export declare class MemberExpression extends Expression {
     constructor(name: string);
     exprOf(): any;
 }
 
-export declare class LogicalExpression implements ExpressionBase {
+export declare class LogicalExpression extends Expression {
 
     static isLogicalOperator(op: string): boolean;
 
@@ -49,29 +54,29 @@ export declare class LogicalExpression implements ExpressionBase {
     exprOf(): any;
 }
 
-export declare class LiteralExpression implements ExpressionBase {
+export declare class LiteralExpression extends Expression {
     constructor(value: any);
     exprOf(): any;
 }
 
-export declare class ComparisonExpression implements ExpressionBase {
+export declare class ComparisonExpression extends Expression {
 
     static isComparisonOperator(op: string): boolean;
     constructor(left: any, operator: string, right:any);
     exprOf(): any;
 }
 
-export declare class MethodCallExpression implements ExpressionBase {
+export declare class MethodCallExpression extends Expression {
     constructor(name: string, args: Array<any>);
     exprOf(): any;
 }
 
-export declare class SequenceExpression implements ExpressionBase {
+export declare class SequenceExpression extends Expression {
     constructor();
     exprOf(): any;
 }
 
-export declare class ObjectExpression implements ExpressionBase {
+export declare class ObjectExpression extends Expression {
     constructor();
     exprOf(): any;
 }

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -1,6 +1,22 @@
 // MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP All rights reserved
-class ArithmeticExpression {
+
+import { AbstractMethodError } from "@themost/common";
+
+/**
+ * @abstract
+ */
+class Expression {
+    constructor() {
+        //
+    }
+    exprOf() {
+        throw new AbstractMethodError();
+    }
+}
+
+class ArithmeticExpression extends Expression {
     constructor(p0, operator, p1) {
+        super();
         this.left = p0;
         this.operator = operator || '$add';
         this.right = p1;
@@ -37,8 +53,9 @@ class ArithmeticExpression {
 ArithmeticExpression.OperatorRegEx = /^(\$add|\$sub|\$mul|\$div|\$mod|\$bit)$/g;
 
 
-class MemberExpression {
+class MemberExpression extends Expression {
     constructor(name) {
+        super();
         this.name = name;
     }
     exprOf() {
@@ -48,8 +65,9 @@ class MemberExpression {
     }
 }
 
-class LogicalExpression {
+class LogicalExpression extends Expression {
     constructor(operator, args) {
+        super();
         this.operator = operator || '$and';
         this.args = args || [];
     }
@@ -83,8 +101,9 @@ class LogicalExpression {
 
 LogicalExpression.OperatorRegEx = /^(\$and|\$or|\$not|\$nor)$/g;
 
-class LiteralExpression {
+class LiteralExpression extends Expression {
     constructor(value) {
+        super();
         this.value = value;
     }
     exprOf() {
@@ -94,8 +113,9 @@ class LiteralExpression {
     }
 }
 
-class ComparisonExpression {
+class ComparisonExpression extends Expression {
     constructor(left, op, right) {
+        super();
         this.left = left;
         this.operator = op || '$eq';
         this.right = right;
@@ -124,8 +144,9 @@ class ComparisonExpression {
 
 ComparisonExpression.OperatorRegEx = /^(\$eq|\$ne|\$lte|\$lt|\$gte|\$gt|\$in|\$nin)$/g;
 
-class MethodCallExpression {
+class MethodCallExpression extends Expression {
     constructor(name, args) {
+        super();
         /**
          * Gets or sets the name of this method
          * @type {String}
@@ -199,8 +220,9 @@ const Operators = {
     BitAnd: '$bit',
 };
 
-class SequenceExpression {
+class SequenceExpression extends Expression {
     constructor() {
+        super();
         this.value = [];
     }
     exprOf() {
@@ -229,9 +251,9 @@ class SequenceExpression {
     }
 }
 
-class ObjectExpression {
+class ObjectExpression extends Expression {
     constructor() {
-        //
+        super();
     }
     exprOf() {
         let finalResult = {};
@@ -310,8 +332,9 @@ class AggregateComparisonExpression extends ComparisonExpression {
 }
 
 
-class SelectAnyExpression {
+class SelectAnyExpression extends Expression {
     constructor(expr, alias) {
+        super();
         this.expression = expr;
         this.as = alias;
     }
@@ -350,8 +373,9 @@ class AnyExpressionFormatter {
     }
 }
 
-class OrderByAnyExpression {
+class OrderByAnyExpression extends Expression {
     constructor(expr, direction) {
+        super();
         this.expression = expr;
         this.direction = direction || 'asc';
     }
@@ -403,6 +427,7 @@ class SwitchExpression extends MethodCallExpression {
 
 export {
     Operators,
+    Expression,
     ArithmeticExpression,
     MemberExpression,
     MethodCallExpression,

--- a/src/query.js
+++ b/src/query.js
@@ -6,6 +6,7 @@ import './polyfills';
 import {ObjectNameValidator} from './object-name.validator';
 import {SyncSeriesEventEmitter} from '@themost/events';
 import { instanceOf } from './instance-of';
+import { Expression } from './expressions';
 
 class QueryParameter {
     constructor() {
@@ -78,12 +79,18 @@ class QueryExpression {
         this.resolvingMethod = new SyncSeriesEventEmitter();
 
         this.resolvingMember.subscribe((event) => {
+            if (event.member instanceof Expression) {
+                return;
+            }
             if (this.$collection) {
                 event.member = this.$collection.concat('.', event.member);
             }
         });
 
         this.resolvingJoinMember.subscribe((event) => {
+            if (event.member instanceof Expression) {
+                return;
+            }
             if (this.$joinCollection != null && event.object == null) {
                 event.object = this.$joinCollection;
             }


### PR DESCRIPTION
This PR closes #92, handles member expressions and allow customizing the derived member when closure parser is trying to resolve it e.g. Use a custom expression syntax when you are querying an order customer and return full name
```javascript
const orders = new QueryEntity('OrderData');
const people = new QueryEntity('PersonData');
const q = new QueryExpression();
q.resolvingMember.subscribe((event) => {
    if (typeof event.member === 'string') {
        const member = event.member.split('.');
        const [,field] = member;
        if (field === 'orderCustomer') {
            event.member = new MethodCallExpression('concat', [
                new QueryField('givenName').from(people),
                new LiteralExpression(' '),
                new QueryField('familyName').from(people),
            ])
        }
    }
})
q.select(
    ({id, orderCustomer}) => {
        return {
            id,
            orderCustomer
        }
    }
).from(orders)
.join(people).with((x, {id}) => x.customer === id, people)
.orderBy(
    ({customer}) => customer
).take(10);
```