### PR TITLE
implement type casting methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2943,6 +2943,23 @@
         "add-peers": "bin/add-peers"
       }
     },
+    "node_modules/@themost/query": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.14.1.tgz",
+      "integrity": "sha512-hfLT/hAU7iHpcI6o5i3IjpGgsUyzX19bz3mSY0NojT2W4Y4rWe8f19UCF6cfWYdHQjPhZIVFHxxTaPhP0DumoA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@themost/events": "^1.0.5",
+        "async": "^3.2.3",
+        "esprima": "^4.0.0",
+        "lodash": "^4.17.21",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.4.0"
+      }
+    },
     "node_modules/@themost/sqlite": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@themost/sqlite/-/sqlite-2.7.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.14.1",
+      "version": "2.14.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/spec/TypeCast.spec.js
+++ b/spec/TypeCast.spec.js
@@ -1,0 +1,78 @@
+import { SqlFormatter, QueryEntity, QueryExpression, QueryField } from '../src/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+import { MemoryFormatter } from './test/TestMemoryFormatter';
+
+describe('Type Casting', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll((done) => {
+        if (db) {
+            db.close();
+            return done();
+        }
+    })
+    it('should use $toString function', async () => {
+        const Product = new QueryEntity('ProductData');
+        const Order = new QueryEntity('OrderData');
+        const id = new QueryField('id').from(Product);
+        let orderedItem = new QueryField('orderedItem').from(Order);
+        let expr = new QueryExpression().where(id).equal(orderedItem);
+        const formatter = new MemoryFormatter();
+        let sql = formatter.formatWhere(expr.$where);
+        expect(sql).toEqual('(`ProductData`.`id`=`OrderData`.`orderedItem`)');
+        orderedItem =new QueryField({
+            '$toString': [
+                new QueryField('orderedItem').from(Order)
+            ]
+        });
+        expr = new QueryExpression().where(id).equal(orderedItem);
+        sql = formatter.formatWhere(expr.$where);
+        expect(sql).toEqual('(`ProductData`.`id`=CAST(`OrderData`.`orderedItem` AS TEXT))');
+    });
+
+    it('should use $toString inside closure', async () => {
+        const Products = new QueryEntity('ProductData');
+        const q = new QueryExpression().select(({id, name, price}) => {
+            return {
+                id,
+                price,
+                priceString: price.toString(),
+                name
+            }
+        }).from(Products);
+        const formatter = new MemoryFormatter();
+        const items = await db.executeAsync(q);
+        items.forEach(({price, priceString}) => {
+            expect(typeof priceString).toEqual('string');
+            const fromString = parseFloat(priceString);
+            expect(price).toEqual(fromString);
+        });
+    });
+
+    it('should use $toInt inside closure', async () => {
+        const Products = new QueryEntity('ProductData');
+        const q = new QueryExpression().select(({id, name, price}) => {
+            return {
+                id,
+                price,
+                priceInt: parseInt(price),
+                name
+            }
+        }).from(Products);
+        const items = await db.executeAsync(q);
+        items.forEach(({price, priceInt}) => {
+            expect(typeof priceInt).toEqual('number');
+            const fromInt = parseInt(price);
+            expect(priceInt).toEqual(fromInt);
+        });
+    });
+});

--- a/spec/test/TestMemoryFormatter.js
+++ b/spec/test/TestMemoryFormatter.js
@@ -1,6 +1,24 @@
 
 import { SqliteFormatter } from '@themost/sqlite';
 
+Object.assign(SqliteFormatter.prototype, {
+    $toString(arg) {
+        return `CAST(${this.escape(arg)} AS TEXT)`;
+    },
+    $toDouble(arg) {
+        return `CAST(${this.escape(arg)} AS NUMERIC)`;
+    },
+    $toDecimal(arg) {
+        return `CAST(${this.escape(arg)} AS NUMERIC)`;
+    },
+    $toInt(arg) {
+        return `CAST(${this.escape(arg)} AS INTEGER)`;
+    },
+    $toLong(arg) {
+        return `CAST(${this.escape(arg)} AS INTEGER)`;
+    }
+});
+
 // noinspection JSUnusedGlobalSymbols
 /**
  * @augments {SqlFormatter}

--- a/src/closures/FallbackMethodParser.js
+++ b/src/closures/FallbackMethodParser.js
@@ -74,6 +74,12 @@ class FallbackMethodParser {
     static now() {
         return new SimpleMethodCallExpression('now', []);
     }
+    static parseInt(args) {
+        return new SimpleMethodCallExpression('toInt', args);
+    }
+    static parseFloat(args) {
+        return new SimpleMethodCallExpression('toDouble', args);
+    }
 }
 
 export {

--- a/src/closures/PrototypeMethodParser.js
+++ b/src/closures/PrototypeMethodParser.js
@@ -1,15 +1,15 @@
-// MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP All rights reserved
+import { SimpleMethodCallExpression } from '../expressions';
 
 class PrototypeMethodParser {
     constructor() {
     }
     test(name) {
-        if (name === 'toString') {
-            return;
-        }
         if (typeof this[name] === 'function') {
             return this[name];
         }
+    }
+    toString(args) {
+        return new SimpleMethodCallExpression('toString', args);
     }
 }
 

--- a/src/formatter.d.ts
+++ b/src/formatter.d.ts
@@ -68,6 +68,11 @@ export declare class SqlFormatter {
     $switch(expr: {
         branches: {case: any, then: any}[], defaultValue?: any
     }): string | any;
+    $toString(arg0:any): string | any;
+    $toInt(arg0:any): string | any;
+    $toDouble(arg0:any): string | any;
+    $toLong(arg0:any): string | any;
+    $toDecimal(arg0:any): string | any;
     formatWhere(where: any): any;
     formatCount(query: QueryExpression | any): any;
     formatFixedSelect(query: QueryExpression | any): any;

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -8,6 +8,12 @@ import './polyfills';
 import { ObjectNameValidator } from './object-name.validator';
 import { isNameReference, trimNameReference } from './name-reference';
 
+class AbstractMethodError extends Error {
+    constructor() {
+        super('Abstract method error')
+    }
+}
+
 const ALIAS_KEYWORD = ' AS ';
 const DEFAULT_COUNT_ALIAS = '__count__';
 /**
@@ -1362,6 +1368,31 @@ class SqlFormatter {
         sql += this.formatWhere(arg);
         sql += ')';
         return sql;
+    }
+
+    /**
+     * @abstract
+     * @param {*} arg 
+     * @returns {string}
+     */
+    $toString(arg) {
+        throw new AbstractMethodError();
+    }
+
+    $toDouble(arg) {
+        throw new AbstractMethodError();
+    }
+
+    $toDecimal(arg) {
+        throw new AbstractMethodError();
+    }
+
+    $toInt(arg) {
+        throw new AbstractMethodError();
+    }
+
+    $toLong(arg) {
+        throw new AbstractMethodError();
     }
 }
 

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1378,19 +1378,42 @@ class SqlFormatter {
     $toString(arg) {
         throw new AbstractMethodError();
     }
-
+    /**
+     * @abstract
+     * @param {*} arg 
+     * @returns {string}
+     */
+     /* eslint-disable-next-line no-unused-vars */
     $toDouble(arg) {
         throw new AbstractMethodError();
     }
 
+    /**
+     * @abstract
+     * @param {*} arg 
+     * @returns {string}
+     */
+     /* eslint-disable-next-line no-unused-vars */
     $toDecimal(arg) {
         throw new AbstractMethodError();
     }
 
+    /**
+     * @abstract
+     * @param {*} arg 
+     * @returns {string}
+     */
+     /* eslint-disable-next-line no-unused-vars */
     $toInt(arg) {
         throw new AbstractMethodError();
     }
 
+    /**
+     * @abstract
+     * @param {*} arg 
+     * @returns {string}
+     */
+     /* eslint-disable-next-line no-unused-vars */
     $toLong(arg) {
         throw new AbstractMethodError();
     }

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1375,6 +1375,7 @@ class SqlFormatter {
      * @param {*} arg 
      * @returns {string}
      */
+    /* eslint-disable-next-line no-unused-vars */
     $toString(arg) {
         throw new AbstractMethodError();
     }


### PR DESCRIPTION
This PR implements type casting methods like `$toString(arg)`, `$toInt(arg)`, `$toDouble(arg)` etc. These methods may be used for generating SQL statements with type casting e.g. `SELECT CAST(price as TEXT) priceString FROM Products`

```js
      const Products = new QueryEntity('ProductData');
      const q = new QueryExpression().select(({id, name, price}) => {
          return {
              id,
              price,
              priceString: price.toString(),
              name
          }
      }).from(Products);
```
which generates the following SQL statement:
```sql
`SELECT `ProductData`.`id` AS `id`, `ProductData`.`price` AS `price`, 
CAST(`ProductData`.`price` AS TEXT) AS `priceString`, `ProductData`.`name` AS `name` FROM `ProductData`
```