### PR TITLE
validate the usage of constant values

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -145,7 +145,7 @@ SqlFormatter.prototype.isLogical = function(obj) {
  */
 SqlFormatter.prototype.escape = function(value,unquoted)
 {
-    if (_.isNil(value))
+    if (value == null)
         return SqlUtils.escape(null);
 
     if (typeof value === 'object')
@@ -155,6 +155,10 @@ SqlFormatter.prototype.escape = function(value,unquoted)
             return SqlUtils.escape(value);
         if (Object.prototype.hasOwnProperty.call(value, '$name')) {
             return this.escapeName(value.$name);
+        } else if (Object.prototype.hasOwnProperty.call(value, '$value')) {
+            return this.escape(value.$value);
+        } else if (Object.prototype.hasOwnProperty.call(value, '$literal')) {
+            return this.escape(value.$literal);
         } else {
             //check if value is a known expression e.g. { $length:"name" }
             var keys = _.keys(value),

--- a/package-lock.json
+++ b/package-lock.json
@@ -2343,13 +2343,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3092,9 +3092,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -6730,13 +6730,13 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -7261,9 +7261,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.5.22",
+  "version": "2.5.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.5.22",
+      "version": "2.5.23",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.22",
+  "version": "2.5.23",
   "description": "MOST Web Framework Codename Blueshift - Query Module",
   "main": "index.js",
   "scripts": {

--- a/query.js
+++ b/query.js
@@ -1723,8 +1723,14 @@ QueryField.fieldNameExpression = /^[A-Za-z_0-9]+$/;
 QueryField.prototype.from = function(entity)
 {
     var name;
-    if (typeof entity !== 'string')
+    var fromEntity;
+    if (entity instanceof QueryEntity) {
+        fromEntity = entity.$as || entity.name;
+    } else if (typeof entity === 'string') {
+        fromEntity = entity;
+    } else {
         throw  new Error('Invalid argument. Expected string');
+    }
     //get property
     if (!_.isNil(this.$name))
     {
@@ -1733,10 +1739,10 @@ QueryField.prototype.from = function(entity)
             name = this.$name;
             if (QueryField.fieldNameExpression.test(name))
             //if not append entity name
-                this.$name = entity.concat('.', name);
+                this.$name = fromEntity.concat('.', name);
             else
             //split field name and add entity
-                this.$name = entity.concat('.', name.split('.')[1]);
+                this.$name = fromEntity.concat('.', name.split('.')[1]);
         }
         else
             throw new Error("Invalid field definition.");
@@ -1755,10 +1761,10 @@ QueryField.prototype.from = function(entity)
         name = expr[aggregate];
         if (QueryField.fieldNameExpression.test(name))
         //if not append entity name
-            expr[aggregate] = entity.concat('.', name);
+            expr[aggregate] = fromEntity.concat('.', name);
         else
         //split field name and add entity
-            expr[aggregate] = entity.concat('.', name.split('.')[1]);
+            expr[aggregate] = fromEntity.concat('.', name.split('.')[1]);
     }
     return this;
 };

--- a/spec/SqlFormatter.select.spec.js
+++ b/spec/SqlFormatter.select.spec.js
@@ -1,0 +1,83 @@
+// eslint-disable-next-line no-unused-vars
+import {QueryEntity, QueryExpression, QueryField} from '../index';
+import { QueryValueRef } from '../query';
+import {MemoryAdapter} from './test/TestMemoryAdapter';
+import Ajv from 'ajv';
+
+// eslint-disable-next-line no-unused-vars
+describe('SqlFormatter', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll(async () => {
+        if (db) {
+            await db.closeAsync();
+        }
+    })
+    it('should format field expression', async () => {
+        const Products = new QueryEntity('ProductData');
+        const q = new QueryExpression().select(
+            new QueryField('id').from(Products),
+            new QueryField('name').from(Products)
+        ).from(Products).take(25);
+        const items = await db.executeAsync(q);
+        expect(items.length).toBeTruthy();
+
+        const schema = {
+            type: 'object',
+            properties: {
+                id: {type: 'number'},
+                name: {type: 'string'}
+            },
+            required: ['id', 'name'],
+            additionalProperties: false
+        };
+
+        const validate = new Ajv().compile(schema);
+        items.forEach((item) => expect(validate(item)).toBeTruthy());
+    });
+
+    it('should format field with method', async () => {
+        const Products = new QueryEntity('ProductData');
+        const q = new QueryExpression().select(
+            new QueryField('id').from(Products),
+            new QueryField({
+                description: {
+                    $concat: [
+                        new QueryField('model').from(Products),
+                        ' ',
+                        new QueryField('name').from(Products),
+                    ]
+                }
+            })
+        ).from(Products).take(25);
+        const items = await db.executeAsync(q);
+        expect(items.length).toBeTruthy();
+        items.forEach((item) => expect(item.description).toBeTruthy());
+    });
+
+    it('should format field with constant', async () => {
+        const Products = new QueryEntity('ProductData');
+        const q = new QueryExpression().select(
+            new QueryField('id').from(Products),
+            new QueryField({
+                status: {
+                    $value: 'active'
+                }
+            })
+        ).from(Products).take(25);
+        const items = await db.executeAsync(q);
+        expect(items.length).toBeTruthy();
+        items.forEach((item) => expect(item.status).toBeTruthy());
+    });
+
+
+});


### PR DESCRIPTION
This PR validates the usage of constant values passed to select query expression e.g.

```js
const Products = new QueryEntity('ProductData');
const q = new QueryExpression().select(
            new QueryField('id').from(Products),
            new QueryField({
                status: {
                    $value: 'active'
                }
            })
 ).from(Products).take(25);
```

which generates an SQL statement like the following:

> `SELECT "ProductData"."id" AS "id", 'active' AS "status" FROM "ProductData" LIMIT 25`