### PR TITLE
fix equal comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.14.3",
+      "version": "2.14.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/query.js
+++ b/src/query.js
@@ -990,7 +990,7 @@ class QueryExpression {
     equal(value) {
         let p0 = this.prop();
         if (p0) {
-            let comparison = value;
+            let comparison = Array.isArray(value) ? { $in: value } : { $eq: value };
             //apply aggregation if any
             if (typeof this[aggregate] === 'object') {
                 comparison = QueryFieldAggregator.prototype.wrapWith.call(this[aggregate], value);
@@ -1014,7 +1014,7 @@ class QueryExpression {
     notEqual(value) {
         let p0 = this.prop();
         if (p0) {
-            let comparison = { $ne: value };
+            let comparison = Array.isArray(value) ? { $nin: value } : { $ne: value };
             if (typeof this[aggregate] === 'object') {
                 comparison = QueryFieldAggregator.prototype.wrapWith.call(this[aggregate], { $ne: value });
                 delete this[aggregate];


### PR DESCRIPTION
This PR forces the usage of `$eq` statement when preparing equal expressions. This operation fixes errors while using method call expressions e.g.

```js
  const query = new QueryExpression()
      .where(
          new QueryField({
              description: {
                  $concat: [
                      new QueryField('givenName'),
                      ' ',
                      new QueryField('familyName'),
                  ]
              }
          })
      ).equal('Cameron Ball');
``` 