### PR TITLE
fix parseSelectSequence with callback

### DIFF
--- a/odata.js
+++ b/odata.js
@@ -210,7 +210,7 @@ OpenDataParser.prototype.atStart = function() {
 
 OpenDataParser.prototype.parseSelectSequence = function(str, callback) {
     return this.parseSelectSequenceAsync(str).then(function(results) {
-        return callback(results);
+        return callback(null, results);
     }).catch(function(err) {
         return callback(err);
     });
@@ -417,11 +417,8 @@ OpenDataParser.prototype.parseExpandItem = function() {
 }
 
 OpenDataParser.prototype.parseOrderBySequence = function(str, callback) {
-    callback = callback || function () {
-        //
-    };
     return this.parseOrderBySequenceAsync(str).then(function(results) {
-        return callback(results);
+        return callback(null, results);
     }).catch(function(err) {
         return callback(err);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.5.28",
+  "version": "2.5.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.5.28",
+      "version": "2.5.29",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.28",
+  "version": "2.5.29",
   "description": "@themost/query is a query builder for SQL. It includes a wide variety of helper functions for building complex SQL queries under node.js.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR validates `OpenDataParser.parseSelectSequence()` and `OpenDataParser.parseOrderBySequence()` and fixes an error occurred due to invalid callback result.