### PR TITLE
validate right operand while escaping an  comparison

### DIFF
--- a/spec/OpenDataQuery.select.spec.js
+++ b/spec/OpenDataQuery.select.spec.js
@@ -259,4 +259,14 @@ describe('OpenDataQuery.select', () => {
         expect(result.$select).toEqual('id,familyName,givenName,concat(concat(givenName,\' \'),familyName) as name');
     });
 
+    it('should use simple or statement', () => {
+        const query = new OpenDataQuery().from('Products')
+            .where('category').equal('Laptops').or('category').equal('Desktops')
+            .orderBy('price')
+            .take(10);
+        const formatter = new OpenDataQueryFormatter();
+        let result = formatter.formatSelect(query);
+        expect(result).toBeTruthy();
+    })
+
 });

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -166,7 +166,14 @@ class SqlFormatter {
                 } else if (keys.length === 1) {
                     // backward compatibility for simple equal expression
                     // e.g. { "category": "Laptops" }
-                    return this.$eq(new QueryField(key0), value[key0]);
+                    const value0 = value[key0];
+                    if (value0 == null) {
+                        return this.$eq(new QueryField(key0), null);
+                    }
+                    if ((typeof value0 === 'object' && Object.prototype.hasOwnProperty.call(value0, '$eq')) === false) {
+                        throw new Error('Invalid right operand. Expected an object with $eq operator.');
+                    }
+                    return this.$eq(new QueryField(key0), value0.$eq);
                 }
             }
         }

--- a/src/open-data-query.formatter.js
+++ b/src/open-data-query.formatter.js
@@ -16,9 +16,12 @@ class OpenDataQueryFormatter extends SqlFormatter {
     }
 
     escapeRight(value) {
+        if (value == null) {
+            return super.escape(value);
+        }
         if (Object.prototype.hasOwnProperty.call(value, '$name'))
             return `$it/${this.escapeName(value.$name)}`;
-        return super.escape(value)
+        return super.escape(value);
     }
 
     $startswith(p0, p1) {


### PR DESCRIPTION
This PR validates the right operand of an `$eq` comparison and follows backward compatibility for escaping an expression like `"category": { "$eq": "Laptops" }` where `$eq` expression does not have an array of arguments eg. 
```javascript
{
    "$eq": [
         new QueryField("category"),
         "Laptops"
     ]
}
```