### PR TITLE
use expression when resolving member

### DIFF
--- a/odata.js
+++ b/odata.js
@@ -7,7 +7,7 @@ var {SwitchExpression, SelectAnyExpression, OrderByAnyExpression, AnyExpressionF
     createLogicalExpression, isArithmeticOperator, createArithmeticExpression,
     isArithmeticExpression, isLogicalExpression, isComparisonOperator,
     createMemberExpression,
-    createComparisonExpression, isMethodCallExpression, isMemberExpression} = require('./expressions');
+    createComparisonExpression, isMethodCallExpression, isMemberExpression, Expression} = require('./expressions');
 var {whilst, series} = require('async');
 const { MethodCallExpression } = require('./expressions');
 /**
@@ -909,7 +909,10 @@ OpenDataParser.prototype.parseMember = function(callback) {
             }
             //search for multiple nested member expression (e.g. a/b/c)
             self.resolveMember(identifier, function(err, member) {
-                callback.call(self, err, createMemberExpression(member));
+                if (member instanceof Expression) {
+                    return callback.call(self, err, member);
+                }
+                return callback.call(self, err, createMemberExpression(member));
             });
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.5.30",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.5.30",
+      "version": "2.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3651,10 +3651,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7280,21 +7281,6 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.5.30",
+  "version": "2.6.0",
   "description": "@themost/query is a query builder for SQL. It includes a wide variety of helper functions for building complex SQL queries under node.js.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates `OpenDataParser` to validate and use the returned value of `resolveMember` method when this value is an instance of `Expression` class e.g. an instance of `MethodCallExpression` class etc. The previous version of the procedure was trying always to create a new instance  of `MemberExpression` avoiding the type of the returned value.