### PR TITLE
use JSON.stringify for serializing object values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.6.70",
+  "version": "2.6.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.6.70",
+      "version": "2.6.71",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.6.70",
+  "version": "2.6.71",
   "description": "@themost/query is a query builder for SQL. It includes a wide variety of helper functions for building complex SQL queries under node.js.",
   "main": "index.js",
   "scripts": {

--- a/utils.js
+++ b/utils.js
@@ -125,7 +125,7 @@ function escape(val, stringifyObjects, timeZone) {
         if (stringifyObjects) {
             val = val.toString();
         } else {
-            return objectToValues(val, timeZone);
+            return `'${JSON.stringify(val)}'`;
         }
     }
     val = val.replace(STR_ESCAPE_REGEXP, function(s) {


### PR DESCRIPTION
This PR applies a change already published at `@themost/query@latest` where objects are being serialized using `JSON.stringify()`.