### PR TITLE
implement $query method dialect

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,8 +37,8 @@ export default [{
         'no-invalid-this': 'warn',
         'no-undef': 'error',
         'no-unused-vars': 'warn',
-        'no-var': ['error'],
-        quotes: ['error', 'single'],
+        'no-var': ['off'],
+        quotes: ['off', 'single'],
         strict: [2, 'never'],
     },
 }, ...compat.extends(

--- a/formatter.js
+++ b/formatter.js
@@ -885,6 +885,18 @@ SqlFormatter.prototype.$bit = function(p0, p1)
      return sprintf('CAST(%s AS char)', this.escape(p0));
  };
 
+ /**
+ * Converts a select query expression to the equivalent statement.
+ * @param arg {QueryExpression|*}
+ */
+ SqlFormatter.prototype.$query = function(arg)
+ {
+    if (typeof arg.$select === 'object') {
+        return Number.isInteger(arg.$take) ? `(${this.formatLimitSelect(arg)})` : `(${this.formatSelect(arg)})`;
+    }
+    throw new Error('Invalid query expression. Expected a valid select expression.');
+ };
+
 /**
  *
  * @param query {QueryExpression|*}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.6.76",
+      "version": "2.6.77",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "description": "@themost/query is a query builder for SQL. It includes a wide variety of helper functions for building complex SQL queries under node.js.",
   "main": "index.js",
   "scripts": {

--- a/spec/QueryExpression.subqueries.spec.js
+++ b/spec/QueryExpression.subqueries.spec.js
@@ -1,0 +1,115 @@
+import { QueryEntity, QueryExpression } from '../index';
+// eslint-disable-next-line no-unused-vars
+import { length, round, max, min, count, avg } from '../closures/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+import { QueryField } from '../query';
+
+describe('Subqueries', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter({
+            name: 'local',
+            database: './spec/db/local.db'
+        });
+    });
+    afterAll((done) => {
+        if (db) {
+            db.close();
+            return done();
+        }
+    });
+
+    it('should use subqueries', async () => {
+        const Orders = new QueryEntity('OrderData');
+        const OrderStatusTypes = new QueryEntity('OrderStatusTypeData').as('orderStatus');
+        const People = new QueryEntity('PersonData');
+        let query = new QueryExpression()
+            .select((x) => {
+                x.id,
+                x.orderDate
+            })
+            .from(Orders)
+            .join(OrderStatusTypes)
+            .with((x, y) => {
+                return x.orderStatus === y.id;
+            })
+            .where((x) => {
+                return x.orderStatus.alternateName === 'OrderPickup';
+            });
+        const {[Orders.name]: select} = query.$select;
+        select.push(new QueryField({
+            customer: {
+                $query: [
+                    new QueryExpression().select(
+                        {
+                            $concat: [
+                                new QueryField('givenName').from(People),
+                                ' ',
+                                new QueryField('familyName').from(People)
+                            ]
+                        }
+                    ).from(People).where(
+                        new QueryField('id').from(People)
+                    ).equal(
+                        new QueryField('customer').from(Orders)
+                    )
+                ]
+            }
+        }))
+        let results = await db.executeAsync(query);
+        expect(results.length).toBeTruthy();
+        results.forEach((item) => {
+            expect(item.customer).toBeTruthy();
+        });
+
+    });
+
+    it('should use aggregate subquery', async () => {
+        const Orders = new QueryEntity('OrderData');
+        const OrderStatusTypes = new QueryEntity('OrderStatusTypeData').as('orderStatus');
+        let query = new QueryExpression()
+            .select((x) => {
+                x.id,
+                x.orderDate
+            })
+            .from(Orders)
+            .join(OrderStatusTypes)
+            .with((x, y) => {
+                return x.orderStatus === y.id;
+            })
+            .where((x) => {
+                return x.orderStatus.alternateName === 'OrderPickup';
+            }).orderByDescending(
+                new QueryField('orderCount')
+            );
+        const {[Orders.name]: select} = query.$select;
+        select.push(new QueryField({
+            orderCount: {
+                $query: [
+                    new QueryExpression().select(
+                        {
+                            $count: [
+                                new QueryField('id').from('a')
+                            ]
+                        }
+                    ).from(new QueryEntity('OrderData').as('a')).where(
+                        new QueryField('customer').from('a')
+                    ).equal(
+                        new QueryField('customer').from(Orders)
+                    )
+                ]
+            }
+        }))
+        let results = await db.executeAsync(query);
+        expect(results.length).toBeTruthy();
+        results.forEach((item) => {
+            expect(item.orderCount).toBeTruthy();
+        });
+
+    });
+
+});


### PR DESCRIPTION
This PR implements `$query` dialect for executing sub-queries in select statements .e.g.

Select a field like the following which calculates the count of order of a customer

```typescript
new QueryField({
    orderCount: {
        $query: [
            new QueryExpression().select(
                {
                    $count: [
                        new QueryField('id').from('q0')
                    ]
                }
            ).from(new QueryEntity('OrderData').as('q0')).where(
                new QueryField('customer').from('q0')
            ).equal(
                new QueryField('customer').from(Orders)
            )
        ]
    }
})
```
This expression can be used by a query expression which is selecting customers. The equivalent SQL statement will be
```sql
(SELECT COUNT("q0"."id") FROM "OrderData" AS "q0" WHERE ("q0"."customer"="PersnoData"."id")) AS "orderCount"
```
