### PR TITLE
format union query expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 [![npm](https://img.shields.io/npm/v/@themost%2Fquery.svg)](https://www.npmjs.com/package/@themost%2Fquery)
-![Dependency status for latest release](https://img.shields.io/librariesio/release/npm/@themost/query)
 ![GitHub top language](https://img.shields.io/github/languages/top/themost-framework/query)
 [![License](https://img.shields.io/npm/l/@themost/query)](https://github.com/themost-framework/themost/blob/master/LICENSE)
 ![GitHub last commit](https://img.shields.io/github/last-commit/themost-framework/query)
 ![GitHub Release Date](https://img.shields.io/github/release-date/themost-framework/query)
 [![npm](https://img.shields.io/npm/dw/@themost/query)](https://www.npmjs.com/package/@themost%2Fquery)
-![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/@themost/query)
 
 ![MOST Web Framework Logo](https://github.com/themost-framework/common/raw/master/docs/img/themost_framework_v3_128.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/query",
-  "version": "2.14.17",
+  "version": "2.14.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/query",
-      "version": "2.14.17",
+      "version": "2.14.18",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@themost/json": "^1.1.0",
         "async": "^3.2.3",
         "esprima": "^4.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "sprintf-js": "^1.1.2"
       },
       "devDependencies": {
@@ -7627,9 +7627,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/query",
-  "version": "2.14.17",
+  "version": "2.14.18",
   "description": "MOST Web Framework Codename ZeroGravity - Query Module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@themost/json": "^1.1.0",
     "async": "^3.2.3",
     "esprima": "^4.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "sprintf-js": "^1.1.2"
   },
   "devDependencies": {

--- a/spec/QueryExpression.union.spec.js
+++ b/spec/QueryExpression.union.spec.js
@@ -1,0 +1,134 @@
+import {QueryEntity, QueryExpression, QueryField} from '../src/index';
+import { MemoryAdapter } from './test/TestMemoryAdapter';
+
+describe('QueryExpression.union', () => {
+
+    /**
+     * @type {MemoryAdapter}
+     */
+    let db;
+    beforeAll(() => {
+        db = new MemoryAdapter();
+    });
+    afterAll(async() => {
+        if (db) {
+            await db.closeAsync();
+        }
+    });
+    it('should use union expression', async () => {
+        const Users = new QueryEntity('UserData');
+        const Groups = new QueryEntity('GroupData');
+        const query = new QueryExpression()
+            .select(
+                new QueryField('name'),
+                new QueryField({ // constant value as field expression
+                    'type': {
+                        $value: 'user'
+                    }
+                })
+            ).from(Users)
+            .union(
+                new QueryExpression().select(
+                    new QueryField('name'),
+                    new QueryField({ // constant value as field expression
+                        'type': {
+                            $value: 'group'
+                        }
+                    })
+                ).from(Groups)
+            )
+        let results = await db.executeAsync(query, []);
+        expect(results.length).toBeTruthy();
+        // find user
+        let found = results.find(({name}) => name === 'alexis.rees@example.com');
+        expect(found).toBeTruthy();
+        found = results.find(({name}) => name === 'Administrators');
+        expect(found).toBeTruthy();
+        expect(found.type).toBe('group');
+    });
+
+    it('should use union expression with limit select', async () => {
+        const Users = new QueryEntity('UserData');
+        const Groups = new QueryEntity('GroupData');
+        const unionQuery = new QueryExpression()
+            .select(
+                new QueryField('name'),
+                new QueryField({ // constant value as field expression
+                    'type': {
+                        $value: 'user'
+                    }
+                })
+            ).from(Users)
+            .union(
+                new QueryExpression().select(
+                    { // select fields as native objects
+                        name: '$name'
+                    },
+                    { // constant value as field expression
+                        'type': {
+                            $value: {
+                                $toString: [
+                                    'group'
+                                ]
+                            }
+                        }
+                    }
+                ).from(Groups)
+            )
+        let results = await db.executeAsync(new QueryExpression().select(
+            'name', 'type'
+        ).from(unionQuery.as('userAndGroups')).take(10) , []);
+        expect(results.length).toEqual(10);
+        // find user
+        let found = results.find(({name}) => name === 'alexis.rees@example.com');
+        expect(found).toBeTruthy();
+        found = results.find(({name}) => name === 'Administrators');
+        expect(found).toBeTruthy();
+        expect(found.type).toBe('group');
+    });
+
+    it('should use union expression with order by', async () => {
+        const Users = new QueryEntity('UserData');
+        const Groups = new QueryEntity('GroupData');
+        const unionQuery = new QueryExpression()
+            .select(
+                new QueryField('name'),
+                new QueryField({ // constant value as field expression
+                    'type': {
+                        $value: 'user'
+                    }
+                }),
+                new QueryField('dateModified').as('dateLastModified'),
+            ).from(Users)
+            .union(
+                new QueryExpression().select(
+                    { // select fields as native objects
+                        name: '$name'
+                    },
+                    { // constant value as field expression
+                        'type': {
+                            $value: {
+                                $toString: [
+                                    'group'
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        'dateLastModified': '$dateModified'
+                    }
+                ).from(Groups)
+            )
+        let results = await db.executeAsync(new QueryExpression().select(
+            'name', 'type', 'dateLastModified'
+        ).from(unionQuery.as('userAndGroups')).take(10).orderBy('dateLastModified') , []);
+        expect(results.length).toEqual(10);
+        // find user
+        let found = results.find(({name}) => name === 'alexis.rees@example.com');
+        expect(found).toBeTruthy();
+        found = results.find(({name}) => name === 'Administrators');
+        expect(found).toBeTruthy();
+        expect(found.type).toBe('group');
+    });
+
+});

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -852,6 +852,13 @@ class SqlFormatter {
         if (isObject(obj.$order))
             sql = sql.concat(this.formatOrder(obj.$order));
 
+        // check if there are union expression to format
+        if (Array.isArray(obj.$unionWith)) {
+            for (const unionWith of obj.$unionWith) {
+                sql += ' UNION ';
+                sql += this.formatSelect(unionWith);
+            }
+        }
         // finally, return statement
         return sql;
     }

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -830,6 +830,13 @@ class SqlFormatter {
                 }
             });
         }
+        // check if there are union expression to format
+        if (Array.isArray(obj.$unionWith)) {
+            for (const unionWith of obj.$unionWith) {
+                sql += ' UNION ';
+                sql += this.formatSelect(unionWith);
+            }
+        }
         //add WHERE statement if any
         if (isObject(obj.$where)) {
             if (isObject(obj.$prepared)) {
@@ -852,13 +859,6 @@ class SqlFormatter {
         if (isObject(obj.$order))
             sql = sql.concat(this.formatOrder(obj.$order));
 
-        // check if there are union expression to format
-        if (Array.isArray(obj.$unionWith)) {
-            for (const unionWith of obj.$unionWith) {
-                sql += ' UNION ';
-                sql += this.formatSelect(unionWith);
-            }
-        }
         // finally, return statement
         return sql;
     }

--- a/src/query.d.ts
+++ b/src/query.d.ts
@@ -5,6 +5,20 @@ export declare type QueryFunc<T> = (value: T, ...param: any[]) => any;
 
 export declare type QueryJoinFunc<T, J> = (value1: T, value2: J, ...param: any[]) => any;
 
+export declare interface QueryExpressionProperties {
+    $additionalSelect?: ( QueryEntity | QueryExpression | string)[];
+    $unionWith?: QueryExpressionProperties[];
+    $select?: any;
+    $delete?: any;
+    $update?: any;
+    $insert?: any;
+    $order?: any;
+    $group?: any;
+    $expand?: any;
+    $where?: any;
+    $fixed?: any;
+}
+
 export declare class QueryExpression {
 
     static ComparisonOperators: {
@@ -34,6 +48,7 @@ export declare class QueryExpression {
     }
 
     $additionalSelect?: ( QueryEntity | QueryExpression | string)[];
+    $unionWith?: QueryExpression[];
     $select?: any;
     $delete?: any;
     $update?: any;
@@ -79,6 +94,7 @@ export declare class QueryExpression {
     crossJoin(entity: (QueryEntity | any)): this;
     with(obj: any): this;
     with<T,J>(expr: (value: T, otherValue: J, ...param: any[]) => any, ...params: any[]): this;
+    union(expr: QueryExpression): this;
     orderBy(expr: string | any): this;
     orderBy<T>(expr: QueryFunc<T>, ...params: any[]): this;
     orderByDescending(expr: string | any): this;

--- a/src/query.js
+++ b/src/query.js
@@ -818,6 +818,20 @@ class QueryExpression {
         //and return QueryExpression
         return this;
     }
+
+    /**
+     * @param {QueryExpression} expr
+     * @returns this
+     */
+    union(expr) {
+        if (this.$select == null) {
+            throw new Error('Select statement cannot be empty when using union operator.');
+        }
+        this.$unionWith = this.$unionWith || [];
+        this.$unionWith.push(expr);
+        return this;
+    }
+
     // noinspection JSUnusedGlobalSymbols
     /**
      * Applies an ascending ordering to a query expression

--- a/src/query.js
+++ b/src/query.js
@@ -827,6 +827,12 @@ class QueryExpression {
         if (this.$select == null) {
             throw new Error('Select statement cannot be empty when using union operator.');
         }
+        if (expr == null) {
+            throw new Error('Union query expression cannot be empty.');
+        }
+        if (Object.keys(expr.$select).length === 0) {
+            throw new Error('Union expression must have a non-empty select statement.');
+        }
         this.$unionWith = this.$unionWith || [];
         this.$unionWith.push(expr);
         return this;


### PR DESCRIPTION
This PR implements `QueryExpression.union(expr)` helper function for using union query expression and allow `SqlFormatter` to generate the equivalent SQL statements.